### PR TITLE
fix: CGO type conversion on Windows

### DIFF
--- a/pkg/internal/connection.go
+++ b/pkg/internal/connection.go
@@ -190,7 +190,7 @@ func (c *Connection) CreateTable(ctx context.Context, name string, schema contra
 		c.handle,
 		cName,
 		cSchemaPtr,
-		C.size_t(len(schemaIPC)),
+		C.size_t(uintptr(len(schemaIPC))),
 	)
 	defer C.simple_lancedb_result_free(result)
 

--- a/pkg/internal/table.go
+++ b/pkg/internal/table.go
@@ -184,7 +184,7 @@ func (t *Table) AddRecords(_ context.Context, records []arrow.Record, _ *contrac
 		t.handle,
 		// #nosec G103 - Safe conversion of Go slice to C array pointer for FFI
 		(*C.uchar)(unsafe.Pointer(&ipcBytes[0])),
-		C.size_t(len(ipcBytes)),
+		C.size_t(uintptr(len(ipcBytes))),
 		&addedCount,
 	)
 	defer C.simple_lancedb_result_free(result)


### PR DESCRIPTION
## Description

This PR fixes CGO type conversion issues on Windows platform when compiling LanceDB Go SDK.

## Problem

On Windows, the following compilation error occurs:
```
cannot use _Ctype_ulong(len(ipcBytes)) (value of uint32 type _Ctype_ulong) as _Ctype_size_t value in variable declaration
```

The root cause is that `len()` returns `int` (actually int32 on Windows), and direct conversion to `C.size_t` (uint64 on 64-bit Windows) causes type mismatch.

## Solution

Use `uintptr` as an intermediate cast:
```go
// Before
C.size_t(len(ipcBytes))

// After
C.size_t(uintptr(len(ipcBytes)))
```

This ensures compatibility across all platforms since `uintptr` is always the same width as a pointer.

## Changes

- Fixed `C.size_t()` conversion in `pkg/internal/table.go` (line 187)
- Fixed `C.size_t()` conversion in `pkg/internal/connection.go` (line 193)
- Both changes use the `uintptr()` intermediate cast pattern

## Testing

✅ Compiles successfully on Windows
✅ No breaking changes to public API
✅ Follows CGO best practices

## Related Issues

Fixes Windows compilation errors for all Windows developers using LanceDB Go SDK.