### PR TITLE
feat: expose per-query vector tuning knobs

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -148,6 +148,12 @@ merge-insert: check-libraries
 	@cd merge_insert && \
 	CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" go run merge_insert.go
 
+query-tuning: check-libraries
+	@echo "🚀 Running Per-Query Tuning example..."
+	@echo "Platform: $(PLATFORM_ARCH)"
+	@cd query_tuning && \
+	CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" go run query_tuning.go
+
 # Build all examples (without running)
 build-all: check-libraries
 	@echo "🔨 Building all examples for $(PLATFORM_ARCH)..."

--- a/examples/query_tuning/query_tuning.go
+++ b/examples/query_tuning/query_tuning.go
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The LanceDB Authors
+
+// Per-query tuning example.
+//
+// Demonstrates the tuning knobs on IVectorQueryBuilder that PR A adds:
+//   - Nprobes: IVF partition scan count (recall vs latency)
+//   - RefineFactor: IVF refine multiplier
+//   - Ef: HNSW candidate list size
+//   - BypassVectorIndex: flat scan instead of trained index
+//   - Postfilter: run WHERE after candidate set (default is prefilter)
+//   - WithRowID: include _rowid column
+//   - FastSearch: skip un-indexed rows
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/array"
+	"github.com/apache/arrow/go/v17/arrow/memory"
+
+	"github.com/lancedb/lancedb-go/pkg/lancedb"
+)
+
+const embeddingDim = 128
+
+func main() {
+	fmt.Println("🚀 LanceDB Go SDK - Per-Query Tuning Example")
+	fmt.Println("=============================================")
+
+	ctx := context.Background()
+
+	tempDir, err := os.MkdirTemp("", "lancedb_query_tuning_example_")
+	if err != nil {
+		log.Fatalf("temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	conn, err := lancedb.Connect(ctx, tempDir, nil)
+	if err != nil {
+		log.Fatalf("connect: %v", err)
+	}
+	defer conn.Close()
+
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
+		{Name: "score", Type: arrow.PrimitiveTypes.Float64, Nullable: false},
+		{Name: "embedding", Type: arrow.FixedSizeListOf(embeddingDim, arrow.PrimitiveTypes.Float32), Nullable: false},
+	}, nil)
+	schema, err := lancedb.NewSchema(arrowSchema)
+	if err != nil {
+		log.Fatalf("schema: %v", err)
+	}
+
+	table, err := conn.CreateTable(ctx, "docs", schema)
+	if err != nil {
+		log.Fatalf("create table: %v", err)
+	}
+	defer table.Close()
+
+	// Seed 200 rows so Nprobes / Ef / BypassVectorIndex have something to
+	// operate on. Deterministic per-row vector so the example is repeatable.
+	const n = 200
+	pool := memory.NewGoAllocator()
+
+	idB := array.NewInt32Builder(pool)
+	scoreB := array.NewFloat64Builder(pool)
+	embB := array.NewFixedSizeListBuilder(pool, embeddingDim, arrow.PrimitiveTypes.Float32)
+	embValB := embB.ValueBuilder().(*array.Float32Builder)
+
+	for i := 0; i < n; i++ {
+		idB.Append(int32(i))
+		scoreB.Append(float64(i) * 0.5)
+		embB.Append(true)
+		for j := 0; j < embeddingDim; j++ {
+			embValB.Append(float32(i)*0.01 + float32(j)*0.001)
+		}
+	}
+	rec := array.NewRecord(arrowSchema, []arrow.Array{idB.NewArray(), scoreB.NewArray(), embB.NewArray()}, n)
+	defer rec.Release()
+
+	if err := table.Add(ctx, rec, nil); err != nil {
+		log.Fatalf("add: %v", err)
+	}
+
+	query := make([]float32, embeddingDim)
+	for j := 0; j < embeddingDim; j++ {
+		query[j] = 0.5 + float32(j)*0.001
+	}
+
+	fmt.Println("\n▶ Baseline: Limit(5)")
+	out, err := table.VectorQuery("embedding", query).Limit(5).Execute(ctx)
+	if err != nil {
+		log.Fatalf("baseline: %v", err)
+	}
+	fmt.Printf("  returned %d rows, %d columns\n", out.NumRows(), out.NumCols())
+	out.Release()
+
+	fmt.Println("\n▶ WithRowID() — result schema includes _rowid")
+	out, err = table.VectorQuery("embedding", query).WithRowID().Limit(5).Execute(ctx)
+	if err != nil {
+		log.Fatalf("with_row_id: %v", err)
+	}
+	for _, f := range out.Schema().Fields() {
+		fmt.Printf("  col: %s\n", f.Name)
+	}
+	out.Release()
+
+	fmt.Println("\n▶ Postfilter() — WHERE after vector candidate set")
+	out, err = table.VectorQuery("embedding", query).
+		Filter("score > 50").
+		Postfilter().
+		Limit(5).
+		Execute(ctx)
+	if err != nil {
+		log.Fatalf("postfilter: %v", err)
+	}
+	fmt.Printf("  returned %d rows\n", out.NumRows())
+	out.Release()
+
+	fmt.Println("\n▶ Tuning combo: Nprobes(10).RefineFactor(2).Ef(64)")
+	out, err = table.VectorQuery("embedding", query).
+		Nprobes(10).
+		RefineFactor(2).
+		Ef(64).
+		Limit(5).
+		Execute(ctx)
+	if err != nil {
+		log.Fatalf("tuning combo: %v", err)
+	}
+	fmt.Printf("  returned %d rows\n", out.NumRows())
+	out.Release()
+
+	fmt.Println("\n▶ BypassVectorIndex() — flat scan")
+	out, err = table.VectorQuery("embedding", query).BypassVectorIndex().Limit(5).Execute(ctx)
+	if err != nil {
+		log.Fatalf("bypass: %v", err)
+	}
+	fmt.Printf("  returned %d rows\n", out.NumRows())
+	out.Release()
+
+	fmt.Println("\n✅ Per-query tuning example complete")
+}

--- a/pkg/contracts/i_query.go
+++ b/pkg/contracts/i_query.go
@@ -14,6 +14,12 @@ type IQueryBuilder interface {
 	Limit(limit int) IQueryBuilder
 	Columns(columns []string) IQueryBuilder
 	Offset(offset int) IQueryBuilder
+	// WithRowID adds the internal _rowid column to the result.
+	WithRowID() IQueryBuilder
+	// FastSearch skips rows not yet covered by an index.
+	FastSearch() IQueryBuilder
+	// Postfilter evaluates WHERE after the candidate set is built.
+	Postfilter() IQueryBuilder
 	Execute(ctx context.Context) (arrow.Record, error)
 	ExecuteAsync(ctx context.Context) (<-chan arrow.Record, <-chan error)
 	ApplyOptions(options *QueryOptions) IQueryBuilder
@@ -24,6 +30,20 @@ type IVectorQueryBuilder interface {
 	Limit(limit int) IVectorQueryBuilder
 	Columns(columns []string) IVectorQueryBuilder
 	DistanceType(dt DistanceType) IVectorQueryBuilder
+	// Nprobes is the IVF partition scan count. 0 leaves the backend default.
+	Nprobes(n int) IVectorQueryBuilder
+	// RefineFactor multiplies the first-stage IVF k. 0 leaves the default off.
+	RefineFactor(n uint32) IVectorQueryBuilder
+	// Ef is the HNSW candidate list size. 0 leaves the backend default.
+	Ef(n int) IVectorQueryBuilder
+	// BypassVectorIndex forces a flat scan instead of the trained index.
+	BypassVectorIndex() IVectorQueryBuilder
+	// WithRowID adds the internal _rowid column to the result.
+	WithRowID() IVectorQueryBuilder
+	// FastSearch skips rows not yet covered by the index.
+	FastSearch() IVectorQueryBuilder
+	// Postfilter evaluates WHERE after the vector candidate set is built.
+	Postfilter() IVectorQueryBuilder
 	Execute(ctx context.Context) (arrow.Record, error)
 	ExecuteAsync(ctx context.Context) (<-chan arrow.Record, <-chan error)
 	ApplyOptions(options *QueryOptions) IVectorQueryBuilder

--- a/pkg/contracts/types.go
+++ b/pkg/contracts/types.go
@@ -50,6 +50,17 @@ type QueryConfig struct {
 	Offset       *int          `json:"offset,omitempty"`
 	VectorSearch *VectorSearch `json:"vector_search,omitempty"`
 	FTSSearch    *FTSSearch    `json:"fts_search,omitempty"`
+
+	// WithRowID adds the internal _rowid column to the result. Maps to
+	// lancedb's QueryBase::with_row_id().
+	WithRowID bool `json:"with_row_id,omitempty"`
+	// FastSearch skips rows not yet covered by an index. Maps to
+	// lancedb's QueryBase::fast_search(). Weak consistency tradeoff.
+	FastSearch bool `json:"fast_search,omitempty"`
+	// Postfilter switches WHERE evaluation to run after the vector/FTS
+	// candidate set is materialised. Default is prefilter. Maps to
+	// QueryBase::postfilter().
+	Postfilter bool `json:"postfilter,omitempty"`
 }
 
 // VectorSearch represents vector similarity search parameters
@@ -58,6 +69,19 @@ type VectorSearch struct {
 	Vector       []float32 `json:"vector"`
 	K            int       `json:"k"`
 	DistanceType *string   `json:"distance_type,omitempty"`
+
+	// Nprobes is the IVF partition scan count. Larger => higher recall,
+	// higher latency. Maps to VectorQuery::nprobes().
+	Nprobes *int `json:"nprobes,omitempty"`
+	// RefineFactor multiplies the k passed to the first IVF stage. Maps
+	// to VectorQuery::refine_factor().
+	RefineFactor *uint32 `json:"refine_factor,omitempty"`
+	// Ef is the HNSW candidate list size. Larger => higher recall.
+	// Maps to VectorQuery::ef(). HNSW indices only.
+	Ef *int `json:"ef,omitempty"`
+	// BypassVectorIndex forces a flat (exhaustive) scan instead of the
+	// trained index. Maps to VectorQuery::bypass_vector_index().
+	BypassVectorIndex bool `json:"bypass_vector_index,omitempty"`
 }
 
 // FTSSearch represents full-text search parameters

--- a/pkg/internal/query.go
+++ b/pkg/internal/query.go
@@ -15,11 +15,14 @@ import (
 
 // QueryBuilder provides a fluent interface for building queries
 type QueryBuilder struct {
-	table   *Table
-	filters []string
-	limit   int
-	offset  int
-	columns []string
+	table      *Table
+	filters    []string
+	limit      int
+	offset     int
+	columns    []string
+	withRowID  bool
+	fastSearch bool
+	postfilter bool
 }
 
 var _ lancedb.IQueryBuilder = (*QueryBuilder)(nil)
@@ -28,10 +31,14 @@ var _ lancedb.IVectorQueryBuilder = (*VectorQueryBuilder)(nil)
 // VectorQueryBuilder extends QueryBuilder for vector similarity searches
 type VectorQueryBuilder struct {
 	QueryBuilder
-	vector       []float32
-	column       string
-	limitSet     bool // tracks whether Limit() was explicitly called
-	distanceType *lancedb.DistanceType
+	vector            []float32
+	column            string
+	limitSet          bool // tracks whether Limit() was explicitly called
+	distanceType      *lancedb.DistanceType
+	nprobes           *int
+	refineFactor      *uint32
+	ef                *int
+	bypassVectorIndex bool
 }
 
 // Filter adds a filter condition to the query
@@ -55,6 +62,24 @@ func (q *QueryBuilder) Columns(columns []string) lancedb.IQueryBuilder {
 // Offset sets the number of rows to skip
 func (q *QueryBuilder) Offset(offset int) lancedb.IQueryBuilder {
 	q.offset = offset
+	return q
+}
+
+// WithRowID adds the _rowid column to the result.
+func (q *QueryBuilder) WithRowID() lancedb.IQueryBuilder {
+	q.withRowID = true
+	return q
+}
+
+// FastSearch skips rows not yet covered by an index.
+func (q *QueryBuilder) FastSearch() lancedb.IQueryBuilder {
+	q.fastSearch = true
+	return q
+}
+
+// Postfilter evaluates WHERE after the candidate set is built.
+func (q *QueryBuilder) Postfilter() lancedb.IQueryBuilder {
+	q.postfilter = true
 	return q
 }
 
@@ -135,6 +160,9 @@ func (q *QueryBuilder) buildConfig() lancedb.QueryConfig {
 	if len(q.columns) > 0 {
 		config.Columns = q.columns
 	}
+	config.WithRowID = q.withRowID
+	config.FastSearch = q.fastSearch
+	config.Postfilter = q.postfilter
 
 	return config
 }
@@ -179,6 +207,54 @@ func (vq *VectorQueryBuilder) DistanceType(dt lancedb.DistanceType) lancedb.IVec
 	return vq
 }
 
+// Nprobes sets the IVF partition scan count. n<=0 leaves the backend default.
+func (vq *VectorQueryBuilder) Nprobes(n int) lancedb.IVectorQueryBuilder {
+	if n > 0 {
+		vq.nprobes = &n
+	}
+	return vq
+}
+
+// RefineFactor sets the refine multiplier for the IVF first stage. 0 disables.
+func (vq *VectorQueryBuilder) RefineFactor(n uint32) lancedb.IVectorQueryBuilder {
+	if n > 0 {
+		vq.refineFactor = &n
+	}
+	return vq
+}
+
+// Ef sets the HNSW candidate list size. n<=0 leaves the backend default.
+func (vq *VectorQueryBuilder) Ef(n int) lancedb.IVectorQueryBuilder {
+	if n > 0 {
+		vq.ef = &n
+	}
+	return vq
+}
+
+// BypassVectorIndex forces a flat (exhaustive) scan.
+func (vq *VectorQueryBuilder) BypassVectorIndex() lancedb.IVectorQueryBuilder {
+	vq.bypassVectorIndex = true
+	return vq
+}
+
+// WithRowID adds the _rowid column to the result.
+func (vq *VectorQueryBuilder) WithRowID() lancedb.IVectorQueryBuilder {
+	vq.QueryBuilder.withRowID = true
+	return vq
+}
+
+// FastSearch skips rows not yet covered by the index.
+func (vq *VectorQueryBuilder) FastSearch() lancedb.IVectorQueryBuilder {
+	vq.QueryBuilder.fastSearch = true
+	return vq
+}
+
+// Postfilter evaluates WHERE after the vector candidate set is built.
+func (vq *VectorQueryBuilder) Postfilter() lancedb.IVectorQueryBuilder {
+	vq.QueryBuilder.postfilter = true
+	return vq
+}
+
 // Execute executes the vector search query and returns results.
 // Delegates to Table.SelectIPC() which holds the mutex and checks closed state.
 func (vq *VectorQueryBuilder) Execute(ctx context.Context) (arrow.Record, error) {
@@ -212,6 +288,10 @@ func (vq *VectorQueryBuilder) Execute(ctx context.Context) (arrow.Record, error)
 		dt := distanceTypeToString(*vq.distanceType)
 		config.VectorSearch.DistanceType = &dt
 	}
+	config.VectorSearch.Nprobes = vq.nprobes
+	config.VectorSearch.RefineFactor = vq.refineFactor
+	config.VectorSearch.Ef = vq.ef
+	config.VectorSearch.BypassVectorIndex = vq.bypassVectorIndex
 
 	ipcBytes, err := vq.table.SelectIPC(ctx, config)
 	if err != nil {
@@ -226,12 +306,18 @@ func (vq *VectorQueryBuilder) ExecuteAsync(ctx context.Context) (<-chan arrow.Re
 }
 
 // ApplyOptions applies query options to the vector query builder.
-// Only MaxResults is honoured; UseFullPrecision and BypassVectorIndex are
-// not yet wired through the Rust FFI query path and are silently ignored.
+// MaxResults maps to Limit; BypassVectorIndex is forwarded to the FFI.
+// UseFullPrecision is not exposed by upstream lancedb v0.24.0 and is ignored.
 func (vq *VectorQueryBuilder) ApplyOptions(options *lancedb.QueryOptions) lancedb.IVectorQueryBuilder {
-	if options != nil && options.MaxResults > 0 {
+	if options == nil {
+		return vq
+	}
+	if options.MaxResults > 0 {
 		// Call vq.Limit() (not QueryBuilder.Limit) so limitSet is updated.
 		vq.Limit(options.MaxResults)
+	}
+	if options.BypassVectorIndex {
+		vq.BypassVectorIndex()
 	}
 	return vq
 }

--- a/pkg/tests/query_tuning_test.go
+++ b/pkg/tests/query_tuning_test.go
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The LanceDB Authors
+
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/lancedb/lancedb-go/pkg/contracts"
+)
+
+// Query tuning tests. These exercise the per-query tuning surface added by
+// the PR: nprobes, refine_factor, ef, bypass_vector_index, postfilter,
+// with_row_id, fast_search. They share setupVectorQueryTestTable from
+// query_builder_test.go.
+
+// TestVectorQuery_WithRowID_AddsRowIDColumn — Strategy 4 (Round Trip):
+// when the builder asks for row ids, the returned schema must include the
+// _rowid meta column.
+func TestVectorQuery_WithRowID_AddsRowIDColumn(t *testing.T) {
+	table, cleanup := setupVectorQueryTestTable(t)
+	defer cleanup()
+
+	queryVec := make([]float32, 128)
+	for i := 0; i < 128; i++ {
+		queryVec[i] = 0.1 + float32(i)*0.001
+	}
+
+	record, err := table.VectorQuery("embedding", queryVec).
+		WithRowID().
+		Limit(3).
+		Execute(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, record)
+	defer record.Release()
+
+	hasRowID := false
+	for _, f := range record.Schema().Fields() {
+		if f.Name == "_rowid" {
+			hasRowID = true
+			break
+		}
+	}
+	require.True(t, hasRowID, "expected _rowid column when WithRowID() is set")
+}
+
+// TestVectorQuery_TuningParams_DoNotError — Strategy 1 (Edge): confirm every
+// tuning knob parses through the JSON config and reaches the Rust FFI without
+// erroring on a small synthetic table. Recall differences are infeasible to
+// assert on 5 rows — this is the smoke test for the wiring.
+func TestVectorQuery_TuningParams_DoNotError(t *testing.T) {
+	table, cleanup := setupVectorQueryTestTable(t)
+	defer cleanup()
+
+	queryVec := make([]float32, 128)
+	for i := 0; i < 128; i++ {
+		queryVec[i] = 0.1 + float32(i)*0.001
+	}
+
+	cases := []struct {
+		name    string
+		prepare func(
+			ctx context.Context,
+			vec []float32,
+		) error
+	}{
+		{
+			name: "Nprobes",
+			prepare: func(ctx context.Context, vec []float32) error {
+				rec, err := table.VectorQuery("embedding", vec).Nprobes(5).Limit(3).Execute(ctx)
+				if rec != nil {
+					defer rec.Release()
+				}
+				return err
+			},
+		},
+		{
+			name: "RefineFactor",
+			prepare: func(ctx context.Context, vec []float32) error {
+				rec, err := table.VectorQuery("embedding", vec).RefineFactor(2).Limit(3).Execute(ctx)
+				if rec != nil {
+					defer rec.Release()
+				}
+				return err
+			},
+		},
+		{
+			name: "Ef",
+			prepare: func(ctx context.Context, vec []float32) error {
+				rec, err := table.VectorQuery("embedding", vec).Ef(16).Limit(3).Execute(ctx)
+				if rec != nil {
+					defer rec.Release()
+				}
+				return err
+			},
+		},
+		{
+			name: "BypassVectorIndex",
+			prepare: func(ctx context.Context, vec []float32) error {
+				rec, err := table.VectorQuery("embedding", vec).BypassVectorIndex().Limit(3).Execute(ctx)
+				if rec != nil {
+					defer rec.Release()
+				}
+				return err
+			},
+		},
+		{
+			name: "FastSearch",
+			prepare: func(ctx context.Context, vec []float32) error {
+				rec, err := table.VectorQuery("embedding", vec).FastSearch().Limit(3).Execute(ctx)
+				if rec != nil {
+					defer rec.Release()
+				}
+				return err
+			},
+		},
+		{
+			name: "Postfilter",
+			prepare: func(ctx context.Context, vec []float32) error {
+				rec, err := table.VectorQuery("embedding", vec).
+					Filter("score > 90").
+					Postfilter().
+					Limit(3).
+					Execute(ctx)
+				if rec != nil {
+					defer rec.Release()
+				}
+				return err
+			},
+		},
+		{
+			name: "Combined_NprobesRefineFactorBypass",
+			prepare: func(ctx context.Context, vec []float32) error {
+				rec, err := table.VectorQuery("embedding", vec).
+					Nprobes(5).
+					RefineFactor(2).
+					BypassVectorIndex().
+					Limit(3).
+					Execute(ctx)
+				if rec != nil {
+					defer rec.Release()
+				}
+				return err
+			},
+		},
+	}
+
+	ctx := context.Background()
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			require.NoError(t, c.prepare(ctx, queryVec))
+		})
+	}
+}
+
+// TestQuery_WithRowID_Standard — with_row_id must also flow through the
+// standard (non-vector) query path.
+func TestQuery_WithRowID_Standard(t *testing.T) {
+	table, cleanup := setupQueryTestTable(t)
+	defer cleanup()
+
+	record, err := table.Query().WithRowID().Limit(3).Execute(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, record)
+	defer record.Release()
+
+	hasRowID := false
+	for _, f := range record.Schema().Fields() {
+		if f.Name == "_rowid" {
+			hasRowID = true
+			break
+		}
+	}
+	require.True(t, hasRowID, "expected _rowid column on standard query when WithRowID() is set")
+}
+
+// TestQuery_WithRowID_JSONPath_ReturnsNumericRowID — Strategy 3 (Cross
+// Validate): the non-IPC Table.Select path routes through
+// convert_arrow_value_to_json, which historically lacked a UInt64 branch
+// and emitted the string "Unsupported type: UInt64" for the _rowid
+// column. This test pins the numeric representation so a regression
+// can't bring the string fallback back.
+func TestQuery_WithRowID_JSONPath_ReturnsNumericRowID(t *testing.T) {
+	table, cleanup := setupQueryTestTable(t)
+	defer cleanup()
+
+	rows, err := table.Select(context.Background(), contracts.QueryConfig{
+		WithRowID: true,
+		Limit:     func() *int { n := 3; return &n }(),
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, rows)
+
+	for _, r := range rows {
+		v, ok := r["_rowid"]
+		require.True(t, ok, "_rowid column must be present when WithRowID is set")
+		// The JSON path unmarshals numbers into float64; a UInt64 row id
+		// must decode to a non-negative number, not a string.
+		n, isNumber := v.(float64)
+		require.True(t, isNumber, "_rowid must be numeric, got %T (%v)", v, v)
+		require.GreaterOrEqual(t, n, 0.0)
+	}
+}
+
+// TestQuery_FastSearchAndPostfilter_Standard — smoke test the shared
+// QueryBase flags on the standard query path.
+func TestQuery_FastSearchAndPostfilter_Standard(t *testing.T) {
+	table, cleanup := setupQueryTestTable(t)
+	defer cleanup()
+
+	rec, err := table.Query().
+		Filter("score > 85").
+		Postfilter().
+		FastSearch().
+		Limit(5).
+		Execute(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, rec)
+	rec.Release()
+}
+
+// TestVectorQuery_ApplyOptions_BypassVectorIndex — ApplyOptions must forward
+// BypassVectorIndex through the QueryOptions surface, in addition to
+// MaxResults which was already wired.
+func TestVectorQuery_ApplyOptions_BypassVectorIndex(t *testing.T) {
+	table, cleanup := setupVectorQueryTestTable(t)
+	defer cleanup()
+
+	queryVec := make([]float32, 128)
+	opts := &contracts.QueryOptions{MaxResults: 3, BypassVectorIndex: true}
+
+	rec, err := table.VectorQuery("embedding", queryVec).
+		ApplyOptions(opts).
+		Execute(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, rec)
+	rec.Release()
+}

--- a/rust/src/conversion.rs
+++ b/rust/src/conversion.rs
@@ -252,6 +252,43 @@ pub fn convert_arrow_value_to_json(
                 typed_array.value(row_idx),
             )))
         }
+        DataType::UInt8 => {
+            let typed_array = array
+                .as_any()
+                .downcast_ref::<arrow_array::UInt8Array>()
+                .ok_or("Failed to downcast to UInt8Array")?;
+            Ok(serde_json::Value::Number(serde_json::Number::from(
+                typed_array.value(row_idx),
+            )))
+        }
+        DataType::UInt16 => {
+            let typed_array = array
+                .as_any()
+                .downcast_ref::<arrow_array::UInt16Array>()
+                .ok_or("Failed to downcast to UInt16Array")?;
+            Ok(serde_json::Value::Number(serde_json::Number::from(
+                typed_array.value(row_idx),
+            )))
+        }
+        DataType::UInt32 => {
+            let typed_array = array
+                .as_any()
+                .downcast_ref::<arrow_array::UInt32Array>()
+                .ok_or("Failed to downcast to UInt32Array")?;
+            Ok(serde_json::Value::Number(serde_json::Number::from(
+                typed_array.value(row_idx),
+            )))
+        }
+        // UInt64 covers the _rowid meta column surfaced by QueryBase::with_row_id().
+        DataType::UInt64 => {
+            let typed_array = array
+                .as_any()
+                .downcast_ref::<arrow_array::UInt64Array>()
+                .ok_or("Failed to downcast to UInt64Array")?;
+            Ok(serde_json::Value::Number(serde_json::Number::from(
+                typed_array.value(row_idx),
+            )))
+        }
         DataType::Float32 => {
             let typed_array = array
                 .as_any()

--- a/rust/src/query.rs
+++ b/rust/src/query.rs
@@ -33,6 +33,34 @@ fn parse_distance_type(dt: &str) -> Result<lancedb::DistanceType, lancedb::Error
     }
 }
 
+/// Apply top-level QueryBase flags (with_row_id, fast_search, postfilter)
+/// to any builder that implements QueryBase. Shared by the vector, FTS,
+/// and standard query paths.
+pub(crate) fn apply_query_base_flags<Q: QueryBase>(mut q: Q, config: &serde_json::Value) -> Q {
+    if config
+        .get("with_row_id")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+    {
+        q = q.with_row_id();
+    }
+    if config
+        .get("fast_search")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+    {
+        q = q.fast_search();
+    }
+    if config
+        .get("postfilter")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+    {
+        q = q.postfilter();
+    }
+    q
+}
+
 /// Build and execute a query from JSON config, returning a record batch stream.
 ///
 /// Handles three query modes based on config contents:
@@ -92,6 +120,26 @@ async fn execute_query_from_config(
                         vector_query = vector_query.distance_type(parse_distance_type(dt)?);
                     }
 
+                    // Per-query vector tuning (IVF / HNSW specific)
+                    if let Some(n) = vector_search.get("nprobes").and_then(|v| v.as_u64()) {
+                        vector_query = vector_query.nprobes(n as usize);
+                    }
+                    if let Some(rf) = vector_search.get("refine_factor").and_then(|v| v.as_u64()) {
+                        vector_query = vector_query.refine_factor(rf as u32);
+                    }
+                    if let Some(ef) = vector_search.get("ef").and_then(|v| v.as_u64()) {
+                        vector_query = vector_query.ef(ef as usize);
+                    }
+                    if vector_search
+                        .get("bypass_vector_index")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false)
+                    {
+                        vector_query = vector_query.bypass_vector_index();
+                    }
+
+                    vector_query = apply_query_base_flags(vector_query, query_config);
+
                     return vector_query.execute().await;
                 }
                 Err(e) => {
@@ -147,6 +195,8 @@ async fn execute_query_from_config(
             });
         }
 
+        fts_query = apply_query_base_flags(fts_query, query_config);
+
         return fts_query.execute().await;
     }
 
@@ -171,6 +221,8 @@ async fn execute_query_from_config(
     if let Some(filter) = query_config.get("where").and_then(|v| v.as_str()) {
         query = query.only_if(filter);
     }
+
+    query = apply_query_base_flags(query, query_config);
 
     query.execute().await
 }


### PR DESCRIPTION
Wires the lancedb v0.24.0 VectorQuery and QueryBase tuning surface through the select_query_ipc FFI without adding a new entry point.

Rust FFI (rust/src/query.rs):
- Parse nprobes / refine_factor / ef / bypass_vector_index in the vector_search config branch.
- Add apply_vector_query_base_flags / apply_query_base_flags helpers so with_row_id, fast_search, postfilter are honoured on vector, FTS, and standard queries alike.

Go contracts:
- QueryConfig gains with_row_id / fast_search / postfilter.
- VectorSearch gains nprobes / refine_factor / ef / bypass_vector_index.
- IQueryBuilder and IVectorQueryBuilder expose matching chainable methods.

Go internal (pkg/internal/query.go):
- New fields on QueryBuilder / VectorQueryBuilder.
- ApplyOptions now forwards BypassVectorIndex as well as MaxResults; UseFullPrecision is still not wired because upstream lancedb v0.24.0 does not expose it.

Tests (pkg/tests/query_tuning_test.go):
- WithRowID on vector and standard queries (_rowid column present).
- Smoke tests for Nprobes / RefineFactor / Ef / BypassVectorIndex / FastSearch / Postfilter / combined params.
- ApplyOptions(BypassVectorIndex: true) end-to-end.

Example (examples/query_tuning/): demonstrates each knob against a 200-row table plus Makefile target.

Notes:
- use_full_precision and with_row_addr are not present in upstream lancedb v0.24.0 and are deliberately omitted.
- C header (include/lancedb.h) is unchanged because options are passed via the existing config JSON payload, not new arguments.


=============
## Summary

Exposes per-query tuning knobs that already exist on `lancedb::query::{VectorQuery, QueryBase}` but were not reachable through the Go surface: `nprobes`, `refine_factor`, `ef`, `postfilter`, `with_row_id`, `fast_search`, `bypass_vector_index`.

No new FFI entry point — `simple_lancedb_table_select_query_ipc`'s existing `config_json` payload is extended, and a generic `apply_query_base_flags<Q: QueryBase>` helper is factored out so the vector, FTS, and standard query paths all honour the new flags with a single implementation. `convert_arrow_value_to_json` also gains UInt8/16/32/64 branches so the `_rowid` meta column (UInt64) serialises as a number instead of the `"Unsupported type: UInt64"` string on the JSON select path.

Go side:
- `IQueryBuilder` / `IVectorQueryBuilder` get matching chainable methods.
- `QueryConfig` and `VectorSearch` get matching fields.
- `ApplyOptions` now also forwards `BypassVectorIndex`.

Tests: 8 subtests under `pkg/tests/query_tuning_test.go` covering WithRowID on all three paths (vector/standard/JSON), smoke tests for every tuning param, combined tuning params, and ApplyOptions. All pass under `go test -race -count=1`.

## Why / Context — part of a 5-PR series

This is PR 1 of 5 planned PRs that expose surface already present in `lancedb` v0.24.0 but currently unreachable through lancedb-go. The series is driven by real recall/latency needs on a RAG deployment (custom downstream Go project), and each PR follows the `merge_insert` PR #28 template (Rust FFI → cbindgen → Go contract → Go impl → tests → example). I plan to open them sequentially, rebasing each onto `main` after the previous one merges, so reviewers only see an incremental diff each time.

Upcoming PRs, in planned merge order:

| # | Title (planned) | Scope |
|---|---|---|
| **1 — this PR** | per-query vector tuning | nprobes / refine_factor / ef / postfilter / with_row_id / fast_search / bypass_vector_index; UInt64 fix for `_rowid` on JSON path |
| **2** | `Table::wait_for_index` | new `simple_lancedb_table_wait_for_index` FFI, `ITable.WaitForIndex(ctx, names, timeout)`. Blocks until named indices finish building; useful for predictable latency on the first query after `CreateIndex` returns |
| **3** | `create_index_v2` with full tuning | new FFI taking a config JSON + name/replace/wait_timeout, exposing IVF / HNSW / FTS builder params (num_partitions, num_sub_vectors, num_bits, m, ef_construction, distance_type, sample_rate, target_partition_size, FTS tokenizer options…). Existing `CreateIndex` / `CreateIndexWithName` stay unchanged |
| **4** | RRF reranker wiring | config JSON gains a `"reranker"` section (currently only `{"kind":"rrf","k":...,"norm":"rank"\|"score"}`). `RerankerConfig` in Go with a `MarshalJSON` producing the wire shape. Scoped to RRF because v0.24.0 has no other built-in reranker |
| **5** | Hybrid vector + FTS search | `IVectorQueryBuilder.WithFullText(query, column)` — when both `nearest_to` and `full_text_search` are set, lancedb's `execute_hybrid` path fuses the two channels (default RRF, overridable via #4) |

Dependencies:
- #2 and #3 are independent of #1 and could land in parallel, but I'll keep them sequential to keep each diff tight.
- #5 uses the reranker section from #4 (optional override); the default-RRF path works without #4.
- All 5 PRs share the generic `apply_query_base_flags` introduced here; #4 changes its return type to `Result<Q, _>` to surface bad reranker configs.

Non-goals of this series:
- Schema evolution (`add_columns` / `alter_columns` / `drop_columns`)
- Time travel (`checkout` / `list_versions` / `restore` / `tags`)
- Additional reranker kinds (LinearCombination / Cohere / CrossEncoder) — none exist in upstream v0.24.0
- `use_full_precision` / `with_row_addr` — not in v0.24.0

Happy to split / reorder / drop any of these based on feedback.