### PR TITLE
feat: expose Table::wait_for_index

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -154,6 +154,12 @@ query-tuning: check-libraries
 	@cd query_tuning && \
 	CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" go run query_tuning.go
 
+wait-for-index: check-libraries
+	@echo "🚀 Running WaitForIndex example..."
+	@echo "Platform: $(PLATFORM_ARCH)"
+	@cd wait_for_index && \
+	CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" go run wait_for_index.go
+
 # Build all examples (without running)
 build-all: check-libraries
 	@echo "🔨 Building all examples for $(PLATFORM_ARCH)..."

--- a/examples/wait_for_index/wait_for_index.go
+++ b/examples/wait_for_index/wait_for_index.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The LanceDB Authors
+
+// WaitForIndex example.
+//
+// Demonstrates how to block until an index finishes building before
+// issuing the first query against it. Useful for boot sequences that
+// want predictable latency on the very first search.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/array"
+	"github.com/apache/arrow/go/v17/arrow/memory"
+
+	"github.com/lancedb/lancedb-go/pkg/contracts"
+	"github.com/lancedb/lancedb-go/pkg/lancedb"
+)
+
+const embeddingDim = 64
+
+func main() {
+	fmt.Println("🚀 LanceDB Go SDK - WaitForIndex Example")
+	fmt.Println("=========================================")
+
+	ctx := context.Background()
+
+	tempDir, err := os.MkdirTemp("", "lancedb_wait_for_index_example_")
+	if err != nil {
+		log.Fatalf("temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	conn, err := lancedb.Connect(ctx, tempDir, nil)
+	if err != nil {
+		log.Fatalf("connect: %v", err)
+	}
+	defer conn.Close()
+
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
+		{Name: "embedding", Type: arrow.FixedSizeListOf(embeddingDim, arrow.PrimitiveTypes.Float32), Nullable: false},
+	}, nil)
+	schema, err := lancedb.NewSchema(arrowSchema)
+	if err != nil {
+		log.Fatalf("schema: %v", err)
+	}
+
+	table, err := conn.CreateTable(ctx, "docs", schema)
+	if err != nil {
+		log.Fatalf("create table: %v", err)
+	}
+	defer table.Close()
+
+	const n = 300
+	pool := memory.NewGoAllocator()
+	idB := array.NewInt32Builder(pool)
+	embB := array.NewFixedSizeListBuilder(pool, embeddingDim, arrow.PrimitiveTypes.Float32)
+	embValB := embB.ValueBuilder().(*array.Float32Builder)
+	for i := 0; i < n; i++ {
+		idB.Append(int32(i))
+		embB.Append(true)
+		for j := 0; j < embeddingDim; j++ {
+			embValB.Append(float32(i)*0.01 + float32(j)*0.001)
+		}
+	}
+	rec := array.NewRecord(arrowSchema, []arrow.Array{idB.NewArray(), embB.NewArray()}, n)
+	defer rec.Release()
+	if err := table.Add(ctx, rec, nil); err != nil {
+		log.Fatalf("add: %v", err)
+	}
+
+	fmt.Println("\n▶ CreateIndex (returns before the index is fully built)")
+	if err := table.CreateIndexWithName(ctx, []string{"embedding"}, contracts.IndexTypeIvfPq, "emb_idx"); err != nil {
+		log.Fatalf("create index: %v", err)
+	}
+
+	fmt.Println("▶ WaitForIndex timeout=30s")
+	start := time.Now()
+	if err := table.WaitForIndex(ctx, []string{"emb_idx"}, 30*time.Second); err != nil {
+		log.Fatalf("wait: %v", err)
+	}
+	fmt.Printf("  done after %s\n", time.Since(start).Round(time.Millisecond))
+
+	stats, err := table.IndexStats(ctx, "emb_idx")
+	if err != nil {
+		log.Fatalf("stats: %v", err)
+	}
+	fmt.Printf("  indexed=%d unindexed=%d\n", stats.NumIndexedRows, stats.NumUnindexedRows)
+
+	fmt.Println("\n✅ WaitForIndex example complete")
+}

--- a/include/lancedb.h
+++ b/include/lancedb.h
@@ -147,6 +147,21 @@ struct SimpleResult *simple_lancedb_table_index_stats(void *table_handle,
                                                       char **index_stats_json);
 
 /**
+ * Wait for the named indices to finish building, with a timeout in
+ * milliseconds. An empty `index_names` array defaults to all indices on
+ * the table. A `timeout_ms` value of 0 means "wait essentially forever"
+ * (Duration::MAX). The call blocks the calling thread until either all
+ * listed indices report no unindexed rows or the deadline elapses.
+ *
+ * Returns SimpleResult::ok() on success, or SimpleResult::error() with a
+ * backend-supplied message on timeout / missing index / I/O failure.
+ */
+struct SimpleResult *simple_lancedb_table_wait_for_index(void *table_handle,
+                                                         const char *const *index_names,
+                                                         size_t index_names_count,
+                                                         uint64_t timeout_ms);
+
+/**
  * Count rows in a table (simple version)
  */
 struct SimpleResult *simple_lancedb_table_count_rows(void *table_handle, int64_t *count);

--- a/pkg/contracts/i_table.go
+++ b/pkg/contracts/i_table.go
@@ -5,6 +5,7 @@ package contracts
 
 import (
 	"context"
+	"time"
 
 	"github.com/apache/arrow/go/v17/arrow"
 )
@@ -66,6 +67,13 @@ type ITable interface {
 
 	// Retrieve statistics about an index
 	IndexStats(ctx context.Context, indexName string) (*IndexStatistics, error)
+
+	// WaitForIndex blocks until the named indexes have finished building
+	// or the timeout elapses. An empty names slice waits for every index
+	// on the table. A zero timeout means "no upper bound" — rely on ctx
+	// cancellation to abort early. Returns an error on timeout, missing
+	// index, or backend failure.
+	WaitForIndex(ctx context.Context, names []string, timeout time.Duration) error
 
 	// Select executes a query with the provided configuration and returns the results
 	Select(ctx context.Context, config QueryConfig) ([]map[string]interface{}, error)

--- a/pkg/internal/table.go
+++ b/pkg/internal/table.go
@@ -17,6 +17,7 @@ import (
 	"math"
 	"runtime"
 	"sync"
+	"time"
 	"unsafe"
 
 	"github.com/apache/arrow/go/v17/arrow"
@@ -484,6 +485,119 @@ func (t *Table) IndexStats(_ context.Context, indexName string) (*contracts.Inde
 	}
 
 	return &indexStats, nil
+}
+
+// WaitForIndex blocks until every index in `names` reports zero unindexed
+// rows or the deadline elapses. An empty `names` slice defers to the
+// backend's "all indices on this table" behaviour.
+//
+// Deadline composition (most-restrictive wins, then forwarded to the
+// Rust side as a single millisecond budget):
+//   - `timeout > 0`           — explicit upper bound from the caller.
+//   - `ctx` carries a deadline — narrows the budget to whichever expires
+//     first. This makes `context.WithTimeout` actually bound the FFI call,
+//     which it didn't in the prior revision.
+//   - `timeout < 0`           — treated as "no wait" (1ms floor).
+//   - `timeout == 0` and ctx has no deadline — wait forever (Rust's
+//     `Duration::MAX`); abort only via process exit.
+//
+// Sub-millisecond positive durations are rounded up to 1ms instead of
+// truncating to 0, which the Rust side would otherwise interpret as
+// "wait forever".
+//
+// Implementation note: lancedb-rust's wait_for_index isn't cancellation
+// aware once it starts, so a bare `ctx.Cancel()` (no deadline) will not
+// interrupt an in-flight call. Callers needing tight cancellation should
+// pass a deadline-bearing ctx or a positive `timeout`.
+//
+//nolint:gocritic
+func (t *Table) WaitForIndex(ctx context.Context, names []string, timeout time.Duration) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	if t.closed || t.handle == nil {
+		return fmt.Errorf("table is closed")
+	}
+
+	// Allocate C strings for each name; keep them alive until after the
+	// FFI call returns so the pointers we hand in stay valid.
+	cNames := make([]*C.char, len(names))
+	for i, n := range names {
+		cNames[i] = C.CString(n)
+	}
+	defer func() {
+		for _, p := range cNames {
+			// #nosec G103 - Required for freeing C allocated string memory
+			C.free(unsafe.Pointer(p))
+		}
+	}()
+
+	var namesPtr **C.char
+	if len(cNames) > 0 {
+		namesPtr = (**C.char)(unsafe.Pointer(&cNames[0]))
+	}
+
+	timeoutMs := ComputeWaitTimeoutMs(ctx, timeout)
+
+	result := C.simple_lancedb_table_wait_for_index(
+		t.handle,
+		namesPtr,
+		C.size_t(len(cNames)),
+		C.uint64_t(timeoutMs),
+	)
+	defer C.simple_lancedb_result_free(result)
+
+	if !result.SUCCESS {
+		if result.ERROR_MESSAGE != nil {
+			errorMsg := C.GoString(result.ERROR_MESSAGE)
+			return fmt.Errorf("wait_for_index failed: %s", errorMsg)
+		}
+		return fmt.Errorf("wait_for_index failed: unknown error")
+	}
+	return nil
+}
+
+// ComputeWaitTimeoutMs folds the caller's `timeout` and any deadline
+// carried by ctx into a single millisecond budget for the Rust side.
+// Returns 0 only when both the caller asks for no upper bound and ctx
+// carries no deadline — that's the only path the Rust side maps to
+// Duration::MAX. Sub-millisecond positive budgets are rounded up to 1
+// to avoid the truncation bug that would otherwise surface them as 0.
+//
+// Exported only so the table-tests package can pin these invariants
+// without spinning up a LanceDB connection per case; not part of the
+// public surface (the contracts package does not re-export it).
+func ComputeWaitTimeoutMs(ctx context.Context, timeout time.Duration) uint64 {
+	// Negative caller timeout: emulate "no wait" with a 1ms floor so the
+	// FFI call returns promptly instead of hanging on Duration::MAX.
+	if timeout < 0 {
+		return 1
+	}
+
+	effective := timeout
+	if dl, ok := ctx.Deadline(); ok {
+		remaining := time.Until(dl)
+		if remaining <= 0 {
+			return 1 // deadline already passed; let the FFI return ASAP
+		}
+		if effective == 0 || remaining < effective {
+			effective = remaining
+		}
+	}
+
+	if effective == 0 {
+		return 0 // caller wants unbounded and ctx has no deadline
+	}
+
+	ms := effective.Milliseconds()
+	if ms < 1 {
+		ms = 1 // floor sub-ms positive durations so they aren't truncated to 0
+	}
+	return uint64(ms)
 }
 
 // Select executes a select query with various predicates (vector search, filters, etc.)

--- a/pkg/tests/wait_for_index_test.go
+++ b/pkg/tests/wait_for_index_test.go
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The LanceDB Authors
+
+package tests
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/array"
+	"github.com/apache/arrow/go/v17/arrow/memory"
+	"github.com/stretchr/testify/require"
+
+	"github.com/lancedb/lancedb-go/pkg/contracts"
+	"github.com/lancedb/lancedb-go/pkg/internal"
+	"github.com/lancedb/lancedb-go/pkg/lancedb"
+)
+
+// setupWaitForIndexTable creates a small table with a vector column. Enough
+// rows are seeded that CreateIndex(IVF_PQ) has to do a real training pass,
+// so WaitForIndex has meaningful work to observe.
+func setupWaitForIndexTable(t *testing.T) (*internal.Table, func()) {
+	t.Helper()
+
+	tempDir, err := os.MkdirTemp("", "lancedb_test_wait_for_index_")
+	require.NoError(t, err)
+
+	conn, err := lancedb.Connect(context.Background(), tempDir, nil)
+	if err != nil {
+		os.RemoveAll(tempDir)
+		t.Fatalf("connect: %v", err)
+	}
+
+	fields := []arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
+		{Name: "embedding", Type: arrow.FixedSizeListOf(64, arrow.PrimitiveTypes.Float32), Nullable: false},
+	}
+	arrowSchema := arrow.NewSchema(fields, nil)
+	schema, err := internal.NewSchema(arrowSchema)
+	if err != nil {
+		conn.Close()
+		os.RemoveAll(tempDir)
+		t.Fatalf("schema: %v", err)
+	}
+
+	table, err := conn.CreateTable(context.Background(), "wfi", schema)
+	if err != nil {
+		conn.Close()
+		os.RemoveAll(tempDir)
+		t.Fatalf("create table: %v", err)
+	}
+
+	const n = 300
+	pool := memory.NewGoAllocator()
+
+	idB := array.NewInt32Builder(pool)
+	embB := array.NewFixedSizeListBuilder(pool, 64, arrow.PrimitiveTypes.Float32)
+	embValB := embB.ValueBuilder().(*array.Float32Builder)
+	for i := 0; i < n; i++ {
+		idB.Append(int32(i))
+		embB.Append(true)
+		for j := 0; j < 64; j++ {
+			embValB.Append(float32(i)*0.01 + float32(j)*0.001)
+		}
+	}
+	rec := array.NewRecord(arrowSchema, []arrow.Array{idB.NewArray(), embB.NewArray()}, n)
+	defer rec.Release()
+
+	if err := table.Add(context.Background(), rec, nil); err != nil {
+		table.Close()
+		conn.Close()
+		os.RemoveAll(tempDir)
+		t.Fatalf("add: %v", err)
+	}
+
+	cleanup := func() {
+		table.Close()
+		conn.Close()
+		os.RemoveAll(tempDir)
+	}
+	return table.(*internal.Table), cleanup
+}
+
+// TestWaitForIndex_ReturnsOnceBuilt — Strategy 4 (Round Trip): CreateIndex
+// returns before the index file is fully materialised; WaitForIndex must
+// block until num_unindexed_rows == 0, after which IndexStats confirms the
+// invariant. A generous timeout keeps the test robust on slow CI workers.
+func TestWaitForIndex_ReturnsOnceBuilt(t *testing.T) {
+	table, cleanup := setupWaitForIndexTable(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	require.NoError(t, table.CreateIndexWithName(ctx, []string{"embedding"}, contracts.IndexTypeIvfPq, "emb_ivf_pq"))
+
+	require.NoError(t, table.WaitForIndex(ctx, []string{"emb_ivf_pq"}, 60*time.Second))
+
+	stats, err := table.IndexStats(ctx, "emb_ivf_pq")
+	require.NoError(t, err)
+	require.NotNil(t, stats)
+	require.Zero(t, stats.NumUnindexedRows, "after WaitForIndex all rows must be indexed")
+}
+
+// TestWaitForIndex_MissingIndex_ReturnsError — Strategy 1 (Edge): the
+// backend surfaces a typed error when the caller asks for an index that
+// doesn't exist; the FFI passes the message through.
+func TestWaitForIndex_MissingIndex_ReturnsError(t *testing.T) {
+	table, cleanup := setupWaitForIndexTable(t)
+	defer cleanup()
+
+	err := table.WaitForIndex(context.Background(), []string{"nonexistent_index"}, 2*time.Second)
+	require.Error(t, err, "missing index must surface an error")
+}
+
+// TestWaitForIndex_ContextCancelled_ShortCircuits — Strategy 1 (Edge): a
+// pre-cancelled ctx must short-circuit before crossing the FFI boundary.
+func TestWaitForIndex_ContextCancelled_ShortCircuits(t *testing.T) {
+	table, cleanup := setupWaitForIndexTable(t)
+	defer cleanup()
+
+	require.NoError(t, table.CreateIndexWithName(context.Background(), []string{"embedding"}, contracts.IndexTypeIvfPq, "emb"))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := table.WaitForIndex(ctx, []string{"emb"}, 10*time.Second)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+// TestWaitForIndex_ClosedTable_ReturnsError — use-after-close guard.
+func TestWaitForIndex_ClosedTable_ReturnsError(t *testing.T) {
+	table, cleanup := setupWaitForIndexTable(t)
+	table.Close()
+	defer cleanup()
+
+	err := table.WaitForIndex(context.Background(), nil, time.Second)
+	require.Error(t, err)
+}
+
+// TestComputeWaitTimeoutMs covers the deadline-folding logic separately
+// so the table-level test doesn't need a LanceDB connection per case.
+// Pins the two Codex-flagged invariants:
+//   - sub-millisecond positive durations don't truncate to 0 (which the
+//     Rust side would interpret as Duration::MAX = wait forever);
+//   - ctx deadlines actually narrow the timeout forwarded to FFI, so
+//     context.WithTimeout becomes a real upper bound on the wait.
+func TestComputeWaitTimeoutMs(t *testing.T) {
+	ctxBg := context.Background()
+	cases := []struct {
+		name    string
+		ctx     func() (context.Context, context.CancelFunc)
+		timeout time.Duration
+		want    uint64
+		wantMin uint64
+		wantMax uint64
+	}{
+		{
+			name:    "explicit_seconds_no_deadline",
+			ctx:     func() (context.Context, context.CancelFunc) { return ctxBg, func() {} },
+			timeout: 5 * time.Second,
+			want:    5000,
+		},
+		{
+			name:    "zero_no_deadline_unbounded",
+			ctx:     func() (context.Context, context.CancelFunc) { return ctxBg, func() {} },
+			timeout: 0,
+			want:    0,
+		},
+		{
+			name:    "submillisecond_floored_to_1",
+			ctx:     func() (context.Context, context.CancelFunc) { return ctxBg, func() {} },
+			timeout: 100 * time.Microsecond,
+			want:    1,
+		},
+		{
+			name:    "negative_returns_1",
+			ctx:     func() (context.Context, context.CancelFunc) { return ctxBg, func() {} },
+			timeout: -5 * time.Second,
+			want:    1,
+		},
+		{
+			name: "deadline_narrows_zero_timeout",
+			ctx: func() (context.Context, context.CancelFunc) {
+				return context.WithTimeout(ctxBg, 2*time.Second)
+			},
+			timeout: 0,
+			wantMin: 100, // give ample slack so test isn't flaky
+			wantMax: 2000,
+		},
+		{
+			name: "deadline_narrows_larger_timeout",
+			ctx: func() (context.Context, context.CancelFunc) {
+				return context.WithTimeout(ctxBg, 1*time.Second)
+			},
+			timeout: 1 * time.Hour,
+			wantMin: 100,
+			wantMax: 1000,
+		},
+		{
+			name: "expired_deadline_returns_1",
+			ctx: func() (context.Context, context.CancelFunc) {
+				c, cancel := context.WithDeadline(ctxBg, time.Now().Add(-time.Second))
+				return c, cancel
+			},
+			timeout: 5 * time.Second,
+			want:    1,
+		},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			ctx, cancel := c.ctx()
+			defer cancel()
+			got := internal.ComputeWaitTimeoutMs(ctx, c.timeout)
+			if c.wantMax > 0 {
+				require.LessOrEqual(t, got, c.wantMax, "got %d ms, want <=%d", got, c.wantMax)
+				require.GreaterOrEqual(t, got, c.wantMin, "got %d ms, want >=%d", got, c.wantMin)
+			} else {
+				require.Equal(t, c.want, got)
+			}
+		})
+	}
+}

--- a/rust/src/index.rs
+++ b/rust/src/index.rs
@@ -7,6 +7,7 @@ use crate::ffi::{from_c_str, SimpleResult};
 use crate::runtime::get_simple_runtime;
 use std::ffi::CString;
 use std::os::raw::{c_char, c_void};
+use std::time::Duration;
 
 /// Create an index on the specified columns
 #[no_mangle]
@@ -293,6 +294,79 @@ pub extern "C" fn simple_lancedb_table_index_stats(
         Ok(res) => Box::into_raw(Box::new(res)),
         Err(_) => Box::into_raw(Box::new(SimpleResult::error(
             "Panic in simple_lancedb_table_index_stats".to_string(),
+        ))),
+    }
+}
+
+/// Wait for the named indices to finish building, with a timeout in
+/// milliseconds. An empty `index_names` array defaults to all indices on
+/// the table. A `timeout_ms` value of 0 means "wait essentially forever"
+/// (Duration::MAX). The call blocks the calling thread until either all
+/// listed indices report no unindexed rows or the deadline elapses.
+///
+/// Returns SimpleResult::ok() on success, or SimpleResult::error() with a
+/// backend-supplied message on timeout / missing index / I/O failure.
+#[no_mangle]
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+pub extern "C" fn simple_lancedb_table_wait_for_index(
+    table_handle: *mut c_void,
+    index_names: *const *const c_char,
+    index_names_count: usize,
+    timeout_ms: u64,
+) -> *mut SimpleResult {
+    let result = std::panic::catch_unwind(|| -> SimpleResult {
+        if table_handle.is_null() {
+            return SimpleResult::error("Invalid null table handle".to_string());
+        }
+        if index_names_count > 0 && index_names.is_null() {
+            return SimpleResult::error(
+                "Non-zero index_names_count requires a non-null array".to_string(),
+            );
+        }
+
+        // Materialise the C string array into Vec<String> so we own the
+        // backing memory for the borrowed Vec<&str> we hand to lancedb.
+        let mut names_owned: Vec<String> = Vec::with_capacity(index_names_count);
+        for i in 0..index_names_count {
+            // SAFETY: caller guarantees index_names points to at least
+            // index_names_count valid *const c_char entries.
+            let raw = unsafe { *index_names.add(i) };
+            if raw.is_null() {
+                return SimpleResult::error(format!("index_names[{}] is a null pointer", i));
+            }
+            match from_c_str(raw) {
+                Ok(s) => names_owned.push(s),
+                Err(e) => {
+                    return SimpleResult::error(format!(
+                        "Invalid UTF-8 in index_names[{}]: {}",
+                        i, e
+                    ))
+                }
+            }
+        }
+        let names_borrowed: Vec<&str> = names_owned.iter().map(String::as_str).collect();
+
+        // 0 means "effectively forever"; the caller can still cancel from
+        // the Go side by letting the table drop.
+        let timeout = if timeout_ms == 0 {
+            Duration::MAX
+        } else {
+            Duration::from_millis(timeout_ms)
+        };
+
+        let table = unsafe { &*(table_handle as *const lancedb::Table) };
+        let rt = get_simple_runtime();
+
+        match rt.block_on(async { table.wait_for_index(&names_borrowed, timeout).await }) {
+            Ok(()) => SimpleResult::ok(),
+            Err(e) => SimpleResult::error(format!("wait_for_index failed: {}", e)),
+        }
+    });
+
+    match result {
+        Ok(res) => Box::into_raw(Box::new(res)),
+        Err(_) => Box::into_raw(Box::new(SimpleResult::error(
+            "Panic in simple_lancedb_table_wait_for_index".to_string(),
         ))),
     }
 }


### PR DESCRIPTION
## Summary

Exposes `lancedb::Table::wait_for_index(&[&str], Duration)` through a new
FFI entry point so callers can block until index build completes.
`CreateIndex` returns before the index file is fully materialised; for
deployments that want predictable latency on the first query after
index creation, this avoids the cold cache hit.

Rust FFI (`rust/src/index.rs`):
- `simple_lancedb_table_wait_for_index(handle, names, n, timeout_ms)`.
- `timeout_ms == 0` maps to `Duration::MAX` — caller cancels via ctx
  on the Go side.
- Builds an owned `Vec<String>` from the C array, then a borrowed
  `Vec<&str>` for `lancedb::Table::wait_for_index`.

Go contract (`pkg/contracts/i_table.go`):
- `ITable.WaitForIndex(ctx, names []string, timeout time.Duration) error`.

Go internal (`pkg/internal/table.go`):
- Honours a pre-cancelled ctx as a short-circuit before crossing the
  FFI boundary, since `lancedb-rust`'s `wait_for_index` is not
  cancellation-aware. Callers needing tight cancellation should pass a
  bounded timeout.

Tests (`pkg/tests/wait_for_index_test.go`):
- `ReturnsOnceBuilt`: after `CreateIndex(IVF_PQ)` and `WaitForIndex`,
  `IndexStats.num_unindexed_rows == 0`.
- `MissingIndex_ReturnsError`: unknown index surfaces a typed error.
- `ContextCancelled_ShortCircuits`: pre-cancelled ctx returns
  `context.Canceled` without entering FFI.
- `ClosedTable_ReturnsError`: use-after-close guard.

Example (`examples/wait_for_index/`): `CreateIndex` → `WaitForIndex` →
`IndexStats` sequence with timing output, plus Makefile target.

C header regenerated by cbindgen.

## Series context

This is **PR 2 of 5** in the series introduced in #29 (already merged).
The roadmap and motivation are documented there; the remaining PRs
will land sequentially once each merges:

- **#29 ✅ merged** — per-query vector tuning
- **this PR** — `Table::wait_for_index`
- **next** — `create_index_v2` with full IVF/HNSW/FTS tuning + name/replace
- **then** — RRF reranker wiring
- **finally** — hybrid vector + FTS search via `WithFullText`