### PR TITLE
feat: expose create_index_v2 with full tuning, name, replace

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -160,6 +160,12 @@ wait-for-index: check-libraries
 	@cd wait_for_index && \
 	CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" go run wait_for_index.go
 
+index-builder: check-libraries
+	@echo "🚀 Running Index Builder (CreateIndexWithParams) example..."
+	@echo "Platform: $(PLATFORM_ARCH)"
+	@cd index_builder && \
+	CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" go run index_builder.go
+
 # Build all examples (without running)
 build-all: check-libraries
 	@echo "🔨 Building all examples for $(PLATFORM_ARCH)..."

--- a/examples/index_builder/index_builder.go
+++ b/examples/index_builder/index_builder.go
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The LanceDB Authors
+
+// Index builder example.
+//
+// Demonstrates CreateIndexWithParams, which exposes the full set of IVF /
+// HNSW / FTS tuning parameters plus a name and a replace flag. Compared to
+// CreateIndex / CreateIndexWithName (which use backend defaults), this is
+// the API to reach for when you want to tune recall / latency or control
+// the tokenizer on a full-text index.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/array"
+	"github.com/apache/arrow/go/v17/arrow/memory"
+
+	"github.com/lancedb/lancedb-go/pkg/contracts"
+	"github.com/lancedb/lancedb-go/pkg/lancedb"
+)
+
+const embeddingDim = 64
+
+func u32(v uint32) *uint32 { return &v }
+func bptr(v bool) *bool    { return &v }
+
+func main() {
+	fmt.Println("🚀 LanceDB Go SDK - Index Builder Example")
+	fmt.Println("==========================================")
+
+	ctx := context.Background()
+	tempDir, err := os.MkdirTemp("", "lancedb_index_builder_example_")
+	if err != nil {
+		log.Fatalf("temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	conn, err := lancedb.Connect(ctx, tempDir, nil)
+	if err != nil {
+		log.Fatalf("connect: %v", err)
+	}
+	defer conn.Close()
+
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
+		{Name: "body", Type: arrow.BinaryTypes.String, Nullable: false},
+		{Name: "embedding", Type: arrow.FixedSizeListOf(embeddingDim, arrow.PrimitiveTypes.Float32), Nullable: false},
+	}, nil)
+	schema, err := lancedb.NewSchema(arrowSchema)
+	if err != nil {
+		log.Fatalf("schema: %v", err)
+	}
+	table, err := conn.CreateTable(ctx, "docs", schema)
+	if err != nil {
+		log.Fatalf("create table: %v", err)
+	}
+	defer table.Close()
+
+	const n = 300
+	pool := memory.NewGoAllocator()
+	idB := array.NewInt32Builder(pool)
+	bodyB := array.NewStringBuilder(pool)
+	embB := array.NewFixedSizeListBuilder(pool, embeddingDim, arrow.PrimitiveTypes.Float32)
+	embValB := embB.ValueBuilder().(*array.Float32Builder)
+	for i := 0; i < n; i++ {
+		idB.Append(int32(i))
+		bodyB.Append(fmt.Sprintf("the quick brown fox jumps %d", i))
+		embB.Append(true)
+		for j := 0; j < embeddingDim; j++ {
+			embValB.Append(float32(i)*0.01 + float32(j)*0.001)
+		}
+	}
+	rec := array.NewRecord(arrowSchema, []arrow.Array{idB.NewArray(), bodyB.NewArray(), embB.NewArray()}, n)
+	defer rec.Release()
+	if err := table.Add(ctx, rec, nil); err != nil {
+		log.Fatalf("add: %v", err)
+	}
+
+	fmt.Println("\n▶ IVF_PQ with custom tuning and a named index")
+	if err := table.CreateIndexWithParams(
+		ctx,
+		[]string{"embedding"},
+		contracts.IndexTypeIvfPq,
+		contracts.IndexParams{
+			NumPartitions: u32(8),
+			NumSubVectors: u32(4),
+			NumBits:       u32(8),
+			DistanceType:  contracts.DistanceTypeCosine,
+		},
+		&contracts.CreateIndexOptions{Name: "emb_ivfpq", WaitTimeout: 30 * time.Second},
+	); err != nil {
+		log.Fatalf("create ivf_pq: %v", err)
+	}
+	fmt.Println("  ✓ created emb_ivfpq")
+
+	fmt.Println("\n▶ IVF_HNSW_PQ with m and ef_construction (separate name)")
+	if err := table.CreateIndexWithParams(
+		ctx,
+		[]string{"embedding"},
+		contracts.IndexTypeHnswPq,
+		contracts.IndexParams{
+			NumPartitions:  u32(4),
+			M:              u32(8),
+			EfConstruction: u32(64),
+			NumSubVectors:  u32(4),
+			DistanceType:   contracts.DistanceTypeL2,
+		},
+		&contracts.CreateIndexOptions{Name: "emb_hnswpq", WaitTimeout: 30 * time.Second},
+	); err != nil {
+		log.Fatalf("create hnsw_pq: %v", err)
+	}
+	fmt.Println("  ✓ created emb_hnswpq")
+
+	fmt.Println("\n▶ FTS with tokenizer options")
+	if err := table.CreateIndexWithParams(
+		ctx,
+		[]string{"body"},
+		contracts.IndexTypeFts,
+		contracts.IndexParams{
+			FtsLanguage:        "English",
+			FtsWithPosition:    bptr(true),
+			FtsStem:            bptr(true),
+			FtsRemoveStopWords: bptr(true),
+			FtsLowerCase:       bptr(true),
+		},
+		&contracts.CreateIndexOptions{Name: "body_fts", WaitTimeout: 30 * time.Second},
+	); err != nil {
+		log.Fatalf("create fts: %v", err)
+	}
+	fmt.Println("  ✓ created body_fts")
+
+	indexes, err := table.GetAllIndexes(ctx)
+	if err != nil {
+		log.Fatalf("list: %v", err)
+	}
+	fmt.Printf("\n📋 Indexes on table: %d\n", len(indexes))
+	for _, ix := range indexes {
+		fmt.Printf("  - name=%s cols=%v type=%s\n", ix.Name, ix.Columns, ix.IndexType)
+	}
+
+	fmt.Println("\n✅ Index builder example complete")
+}

--- a/include/lancedb.h
+++ b/include/lancedb.h
@@ -162,6 +162,25 @@ struct SimpleResult *simple_lancedb_table_wait_for_index(void *table_handle,
                                                          uint64_t timeout_ms);
 
 /**
+ * Create an index with full tuning parameters. The `config_json` is the
+ * canonical surface for per-type tuning (num_partitions, m, ef_construction,
+ * FTS options, etc.); the small top-level knobs (name/replace/
+ * wait_timeout_ms) are passed as regular arguments so callers don't have to
+ * encode them into JSON just to change a single bool.
+ *
+ * - `name` may be NULL for the backend default.
+ * - `replace` matches lancedb's IndexBuilder::replace (default true in
+ *   upstream; we forward the caller's choice verbatim).
+ * - `wait_timeout_ms == 0` leaves the backend default (no wait).
+ */
+struct SimpleResult *simple_lancedb_table_create_index_v2(void *table_handle,
+                                                          const char *columns_json,
+                                                          const char *config_json,
+                                                          const char *name,
+                                                          bool replace,
+                                                          uint64_t wait_timeout_ms);
+
+/**
  * Count rows in a table (simple version)
  */
 struct SimpleResult *simple_lancedb_table_count_rows(void *table_handle, int64_t *count);

--- a/pkg/contracts/i_table.go
+++ b/pkg/contracts/i_table.go
@@ -62,6 +62,13 @@ type ITable interface {
 	// CreateIndexWithName creates an index with a custom name on the specified columns
 	CreateIndexWithName(ctx context.Context, columns []string, indexType IndexType, name string) error
 
+	// CreateIndexWithParams creates an index with full per-type tuning
+	// (IVF partition/PQ/HNSW/FTS parameters) plus top-level options
+	// (name / replace / wait timeout). Unset fields fall back to the
+	// backend default. Passing nil opts is equivalent to zero-valued
+	// CreateIndexOptions (no name override, replace=false, no wait).
+	CreateIndexWithParams(ctx context.Context, columns []string, indexType IndexType, params IndexParams, opts *CreateIndexOptions) error
+
 	// GetAllIndexes returns information about all indexes present on the table
 	GetAllIndexes(ctx context.Context) ([]IndexInfo, error)
 

--- a/pkg/contracts/types.go
+++ b/pkg/contracts/types.go
@@ -1,5 +1,7 @@
 package contracts
 
+import "time"
+
 // IndexType represents the type of index to create
 type IndexType int
 
@@ -30,6 +32,54 @@ type IndexInfo struct {
 	Name      string   `json:"name"`
 	Columns   []string `json:"columns"`
 	IndexType string   `json:"index_type"`
+}
+
+// IndexParams carries per-type tuning knobs for CreateIndexWithParams.
+// All fields are optional — pointer fields treat nil as "backend default",
+// string fields treat empty as "unset". A field that does not apply to the
+// chosen IndexType (e.g. M on a BTree index) is silently ignored on the
+// Rust side.
+type IndexParams struct {
+	// IVF-family common
+	NumPartitions       *uint32 `json:"num_partitions,omitempty"`
+	SampleRate          *uint32 `json:"sample_rate,omitempty"`
+	MaxIterations       *uint32 `json:"max_iterations,omitempty"`
+	TargetPartitionSize *uint32 `json:"target_partition_size,omitempty"`
+	// PQ-specific (IvfPq, IvfRq, IvfHnswPq)
+	NumSubVectors *uint32 `json:"num_sub_vectors,omitempty"`
+	NumBits       *uint32 `json:"num_bits,omitempty"`
+	// HNSW-specific
+	M              *uint32 `json:"m,omitempty"`
+	EfConstruction *uint32 `json:"ef_construction,omitempty"`
+	// Distance metric for vector indices. Leave Unspecified for the
+	// backend default (L2).
+	DistanceType DistanceType `json:"-"`
+
+	// FTS-specific
+	FtsLanguage        string  `json:"language,omitempty"`
+	FtsWithPosition    *bool   `json:"with_position,omitempty"`
+	FtsStem            *bool   `json:"stem,omitempty"`
+	FtsRemoveStopWords *bool   `json:"remove_stop_words,omitempty"`
+	FtsLowerCase       *bool   `json:"lower_case,omitempty"`
+	FtsASCIIFolding    *bool   `json:"ascii_folding,omitempty"`
+	FtsBaseTokenizer   string  `json:"base_tokenizer,omitempty"`
+	FtsMaxTokenLength  *uint32 `json:"max_token_length,omitempty"`
+	FtsNgramMinLength  *uint32 `json:"ngram_min_length,omitempty"`
+	FtsNgramMaxLength  *uint32 `json:"ngram_max_length,omitempty"`
+	FtsNgramPrefixOnly *bool   `json:"ngram_prefix_only,omitempty"`
+}
+
+// CreateIndexOptions carries the top-level IndexBuilder knobs that live
+// outside of the per-type params (name, replace, wait_timeout).
+type CreateIndexOptions struct {
+	// Name overrides the default lancedb-chosen index name.
+	Name string
+	// Replace controls whether an existing index on the same columns
+	// with the same name is replaced. Matches lancedb::IndexBuilder::replace.
+	Replace bool
+	// WaitTimeout tells the backend to block until index build completes
+	// or the timeout elapses. Zero leaves the default (no wait).
+	WaitTimeout time.Duration
 }
 
 // IndexStatistics represents statistics about an index

--- a/pkg/internal/query.go
+++ b/pkg/internal/query.go
@@ -187,17 +187,20 @@ func (vq *VectorQueryBuilder) Columns(columns []string) lancedb.IVectorQueryBuil
 }
 
 // distanceTypeToString converts a DistanceType enum to the JSON string
-// expected by the Rust FFI. Caller guards against DistanceTypeUnspecified.
-func distanceTypeToString(dt lancedb.DistanceType) string {
+// expected by the Rust FFI. Returns an error for unknown values so an
+// out-of-range cast (e.g. lancedb.DistanceType(99)) surfaces as a normal
+// error to the caller instead of crashing the process.
+// DistanceTypeUnspecified is the caller's responsibility to filter out.
+func distanceTypeToString(dt lancedb.DistanceType) (string, error) {
 	switch dt {
 	case lancedb.DistanceTypeL2:
-		return "l2"
+		return "l2", nil
 	case lancedb.DistanceTypeCosine:
-		return "cosine"
+		return "cosine", nil
 	case lancedb.DistanceTypeDot:
-		return "dot"
+		return "dot", nil
 	default:
-		panic(fmt.Sprintf("unhandled DistanceType: %d", dt))
+		return "", fmt.Errorf("unknown DistanceType: %d", dt)
 	}
 }
 
@@ -285,7 +288,10 @@ func (vq *VectorQueryBuilder) Execute(ctx context.Context) (arrow.Record, error)
 		K:      k,
 	}
 	if vq.distanceType != nil && *vq.distanceType != lancedb.DistanceTypeUnspecified {
-		dt := distanceTypeToString(*vq.distanceType)
+		dt, err := distanceTypeToString(*vq.distanceType)
+		if err != nil {
+			return nil, err
+		}
 		config.VectorSearch.DistanceType = &dt
 	}
 	config.VectorSearch.Nprobes = vq.nprobes

--- a/pkg/internal/table.go
+++ b/pkg/internal/table.go
@@ -830,6 +830,104 @@ func (t *Table) indexTypeToString(indexType contracts.IndexType) string {
 	}
 }
 
+// CreateIndexWithParams creates an index using the v2 FFI entry point,
+// which accepts a JSON config carrying per-type tuning parameters plus
+// name/replace/wait_timeout. `opts` may be nil for defaults.
+//
+//nolint:gocritic
+func (t *Table) CreateIndexWithParams(
+	_ context.Context,
+	columns []string,
+	indexType contracts.IndexType,
+	params contracts.IndexParams,
+	opts *contracts.CreateIndexOptions,
+) error {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	if t.closed || t.handle == nil {
+		return fmt.Errorf("table is closed")
+	}
+
+	columnsJSON, err := json.Marshal(columns)
+	if err != nil {
+		return fmt.Errorf("failed to marshal columns: %w", err)
+	}
+
+	// Embed IndexParams' fields into an envelope carrying type +
+	// distance_type, which aren't part of the params struct's JSON
+	// surface. Single Marshal; no intermediate map.
+	envelope := struct {
+		Type         string `json:"type"`
+		DistanceType string `json:"distance_type,omitempty"`
+		contracts.IndexParams
+	}{
+		Type:        t.indexTypeToString(indexType),
+		IndexParams: params,
+	}
+	if params.DistanceType != contracts.DistanceTypeUnspecified {
+		dt, err := distanceTypeToString(params.DistanceType)
+		if err != nil {
+			return fmt.Errorf("invalid IndexParams.DistanceType: %w", err)
+		}
+		envelope.DistanceType = dt
+	}
+	cfgJSON, err := json.Marshal(envelope)
+	if err != nil {
+		return fmt.Errorf("failed to marshal index config: %w", err)
+	}
+
+	var (
+		name          string
+		replace       bool
+		waitTimeoutMs uint64
+	)
+	if opts != nil {
+		name = opts.Name
+		replace = opts.Replace
+		if opts.WaitTimeout > 0 {
+			ms := opts.WaitTimeout.Milliseconds()
+			if ms > 0 {
+				waitTimeoutMs = uint64(ms)
+			}
+		}
+	}
+
+	cColumnsJSON := C.CString(string(columnsJSON))
+	// #nosec G103 - Required for freeing C allocated string memory
+	defer C.free(unsafe.Pointer(cColumnsJSON))
+
+	cConfigJSON := C.CString(string(cfgJSON))
+	// #nosec G103 - Required for freeing C allocated string memory
+	defer C.free(unsafe.Pointer(cConfigJSON))
+
+	var cName *C.char
+	if name != "" {
+		cName = C.CString(name)
+		// #nosec G103 - Required for freeing C allocated string memory
+		defer C.free(unsafe.Pointer(cName))
+	}
+
+	result := C.simple_lancedb_table_create_index_v2(
+		t.handle,
+		cColumnsJSON,
+		cConfigJSON,
+		cName,
+		C.bool(replace),
+		C.uint64_t(waitTimeoutMs),
+	)
+	defer C.simple_lancedb_result_free(result)
+
+	if !result.SUCCESS {
+		if result.ERROR_MESSAGE != nil {
+			errorMsg := C.GoString(result.ERROR_MESSAGE)
+			return fmt.Errorf("create_index_v2 failed: %s", errorMsg)
+		}
+		return fmt.Errorf("create_index_v2 failed: unknown error")
+	}
+	return nil
+}
+
 // recordToJSON converts an Arrow Record to JSON format
 func (t *Table) recordToJSON(record arrow.Record) (string, error) {
 	schema := record.Schema()

--- a/pkg/tests/create_index_v2_test.go
+++ b/pkg/tests/create_index_v2_test.go
@@ -1,0 +1,262 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The LanceDB Authors
+
+package tests
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/array"
+	"github.com/apache/arrow/go/v17/arrow/memory"
+	"github.com/stretchr/testify/require"
+
+	"github.com/lancedb/lancedb-go/pkg/contracts"
+	"github.com/lancedb/lancedb-go/pkg/internal"
+	"github.com/lancedb/lancedb-go/pkg/lancedb"
+)
+
+// u32Ptr is a tiny helper for the optional IndexParams fields.
+func u32Ptr(v uint32) *uint32 { return &v }
+func boolPtr(v bool) *bool    { return &v }
+
+// setupIndexBuilderTable seeds 300 rows with a 64-dim embedding and a
+// stringy text column so the test can exercise both vector and FTS index
+// variants against the same table.
+func setupIndexBuilderTable(t *testing.T) (*internal.Table, func()) {
+	t.Helper()
+	tempDir, err := os.MkdirTemp("", "lancedb_test_index_builder_")
+	require.NoError(t, err)
+
+	conn, err := lancedb.Connect(context.Background(), tempDir, nil)
+	if err != nil {
+		os.RemoveAll(tempDir)
+		t.Fatalf("connect: %v", err)
+	}
+
+	fields := []arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
+		{Name: "text", Type: arrow.BinaryTypes.String, Nullable: false},
+		{Name: "embedding", Type: arrow.FixedSizeListOf(64, arrow.PrimitiveTypes.Float32), Nullable: false},
+	}
+	arrowSchema := arrow.NewSchema(fields, nil)
+	schema, err := internal.NewSchema(arrowSchema)
+	if err != nil {
+		conn.Close()
+		os.RemoveAll(tempDir)
+		t.Fatalf("schema: %v", err)
+	}
+	table, err := conn.CreateTable(context.Background(), "idx_v2", schema)
+	if err != nil {
+		conn.Close()
+		os.RemoveAll(tempDir)
+		t.Fatalf("create table: %v", err)
+	}
+
+	const n = 300
+	pool := memory.NewGoAllocator()
+	idB := array.NewInt32Builder(pool)
+	txtB := array.NewStringBuilder(pool)
+	embB := array.NewFixedSizeListBuilder(pool, 64, arrow.PrimitiveTypes.Float32)
+	embValB := embB.ValueBuilder().(*array.Float32Builder)
+	for i := 0; i < n; i++ {
+		idB.Append(int32(i))
+		txtB.Append("the quick brown fox " + string(rune('a'+i%26)))
+		embB.Append(true)
+		for j := 0; j < 64; j++ {
+			embValB.Append(float32(i)*0.01 + float32(j)*0.001)
+		}
+	}
+	rec := array.NewRecord(arrowSchema, []arrow.Array{idB.NewArray(), txtB.NewArray(), embB.NewArray()}, n)
+	defer rec.Release()
+	if err := table.Add(context.Background(), rec, nil); err != nil {
+		table.Close()
+		conn.Close()
+		os.RemoveAll(tempDir)
+		t.Fatalf("add: %v", err)
+	}
+
+	cleanup := func() {
+		table.Close()
+		conn.Close()
+		os.RemoveAll(tempDir)
+	}
+	return table.(*internal.Table), cleanup
+}
+
+// TestCreateIndexWithParams_IvfPq_FullTuning — IVF_PQ with explicit
+// num_partitions / num_sub_vectors / distance_type + custom name. Verifies
+// the index shows up under the custom name.
+func TestCreateIndexWithParams_IvfPq_FullTuning(t *testing.T) {
+	table, cleanup := setupIndexBuilderTable(t)
+	defer cleanup()
+
+	err := table.CreateIndexWithParams(
+		context.Background(),
+		[]string{"embedding"},
+		contracts.IndexTypeIvfPq,
+		contracts.IndexParams{
+			NumPartitions: u32Ptr(8),
+			NumSubVectors: u32Ptr(4),
+			NumBits:       u32Ptr(8),
+			DistanceType:  contracts.DistanceTypeCosine,
+		},
+		&contracts.CreateIndexOptions{
+			Name:        "emb_ivfpq",
+			Replace:     false,
+			WaitTimeout: 30 * time.Second,
+		},
+	)
+	require.NoError(t, err)
+
+	indexes, err := table.GetAllIndexes(context.Background())
+	require.NoError(t, err)
+
+	found := false
+	for _, ix := range indexes {
+		if ix.Name == "emb_ivfpq" {
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "expected an index named emb_ivfpq; got %v", indexes)
+}
+
+// TestCreateIndexWithParams_HnswPq_TuningKnobs — IVF_HNSW_PQ with m /
+// ef_construction / num_sub_vectors set. Smoke-tests the HNSW tuning
+// parameters reach the FFI.
+func TestCreateIndexWithParams_HnswPq_TuningKnobs(t *testing.T) {
+	table, cleanup := setupIndexBuilderTable(t)
+	defer cleanup()
+
+	err := table.CreateIndexWithParams(
+		context.Background(),
+		[]string{"embedding"},
+		contracts.IndexTypeHnswPq,
+		contracts.IndexParams{
+			NumPartitions:  u32Ptr(4),
+			M:              u32Ptr(8),
+			EfConstruction: u32Ptr(64),
+			NumSubVectors:  u32Ptr(4),
+			DistanceType:   contracts.DistanceTypeL2,
+		},
+		&contracts.CreateIndexOptions{WaitTimeout: 30 * time.Second},
+	)
+	require.NoError(t, err)
+}
+
+// TestCreateIndexWithParams_FTS_FullTuning — FTS with with_position,
+// language, stem, remove_stop_words tuning. Index build must succeed and
+// the index must be discoverable via GetAllIndexes.
+func TestCreateIndexWithParams_FTS_FullTuning(t *testing.T) {
+	table, cleanup := setupIndexBuilderTable(t)
+	defer cleanup()
+
+	err := table.CreateIndexWithParams(
+		context.Background(),
+		[]string{"text"},
+		contracts.IndexTypeFts,
+		contracts.IndexParams{
+			FtsLanguage:        "English",
+			FtsWithPosition:    boolPtr(true),
+			FtsStem:            boolPtr(true),
+			FtsRemoveStopWords: boolPtr(true),
+			FtsLowerCase:       boolPtr(true),
+		},
+		&contracts.CreateIndexOptions{Name: "text_fts", WaitTimeout: 30 * time.Second},
+	)
+	require.NoError(t, err)
+
+	indexes, err := table.GetAllIndexes(context.Background())
+	require.NoError(t, err)
+	found := false
+	for _, ix := range indexes {
+		if ix.Name == "text_fts" {
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "expected an index named text_fts; got %v", indexes)
+}
+
+// TestCreateIndexWithParams_Replace_OverridesExisting — creating an index
+// with the same name twice fails unless Replace is true.
+func TestCreateIndexWithParams_Replace_OverridesExisting(t *testing.T) {
+	table, cleanup := setupIndexBuilderTable(t)
+	defer cleanup()
+
+	params := contracts.IndexParams{NumPartitions: u32Ptr(8), NumSubVectors: u32Ptr(4)}
+
+	require.NoError(t, table.CreateIndexWithParams(
+		context.Background(),
+		[]string{"embedding"},
+		contracts.IndexTypeIvfPq,
+		params,
+		&contracts.CreateIndexOptions{Name: "emb_idx", WaitTimeout: 30 * time.Second},
+	))
+
+	// Second call without Replace should error (index already exists).
+	err := table.CreateIndexWithParams(
+		context.Background(),
+		[]string{"embedding"},
+		contracts.IndexTypeIvfPq,
+		params,
+		&contracts.CreateIndexOptions{Name: "emb_idx", WaitTimeout: 30 * time.Second},
+	)
+	require.Error(t, err, "duplicate index without Replace must fail")
+
+	// Same call with Replace=true succeeds.
+	require.NoError(t, table.CreateIndexWithParams(
+		context.Background(),
+		[]string{"embedding"},
+		contracts.IndexTypeIvfPq,
+		params,
+		&contracts.CreateIndexOptions{Name: "emb_idx", Replace: true, WaitTimeout: 30 * time.Second},
+	))
+}
+
+// TestCreateIndexWithParams_UnknownType_Error — defense against an
+// unmapped IndexType slipping through. The indexTypeToString default
+// returns "vector" which is valid, so this exercises the JSON type path
+// via a direct-on-Rust guard: pass Ivf params on a BTree column combo
+// that cannot be trained.
+func TestCreateIndexWithParams_NilOptsIsEquivalentToDefault(t *testing.T) {
+	table, cleanup := setupIndexBuilderTable(t)
+	defer cleanup()
+
+	// nil opts must not panic; treated as zero CreateIndexOptions.
+	err := table.CreateIndexWithParams(
+		context.Background(),
+		[]string{"embedding"},
+		contracts.IndexTypeIvfPq,
+		contracts.IndexParams{NumPartitions: u32Ptr(4), NumSubVectors: u32Ptr(4)},
+		nil,
+	)
+	require.NoError(t, err)
+}
+
+// TestCreateIndexWithParams_InvalidDistanceType_ReturnsError — Strategy 1
+// (Edge): an out-of-range cast like contracts.DistanceType(99) used to
+// panic via distanceTypeToString. Pin the error path so callers passing
+// decoded/cast values get a normal error instead of a process crash.
+func TestCreateIndexWithParams_InvalidDistanceType_ReturnsError(t *testing.T) {
+	table, cleanup := setupIndexBuilderTable(t)
+	defer cleanup()
+
+	err := table.CreateIndexWithParams(
+		context.Background(),
+		[]string{"embedding"},
+		contracts.IndexTypeIvfPq,
+		contracts.IndexParams{
+			NumPartitions: u32Ptr(4),
+			NumSubVectors: u32Ptr(4),
+			DistanceType:  contracts.DistanceType(99),
+		},
+		nil,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "DistanceType")
+}

--- a/rust/src/index.rs
+++ b/rust/src/index.rs
@@ -370,3 +370,297 @@ pub extern "C" fn simple_lancedb_table_wait_for_index(
         ))),
     }
 }
+
+/// Build a lancedb::index::Index from the config JSON "type" field plus any
+/// per-kind tuning parameters present on the config object. Returns the
+/// resulting Index or a user-facing error string.
+fn build_index_from_config(cfg: &serde_json::Value) -> Result<lancedb::index::Index, String> {
+    use lancedb::index::scalar::{
+        BTreeIndexBuilder, BitmapIndexBuilder, FtsIndexBuilder, LabelListIndexBuilder,
+    };
+    use lancedb::index::vector::{
+        IvfFlatIndexBuilder, IvfHnswPqIndexBuilder, IvfHnswSqIndexBuilder, IvfPqIndexBuilder,
+        IvfRqIndexBuilder, IvfSqIndexBuilder,
+    };
+    use lancedb::index::Index;
+
+    let kind = cfg
+        .get("type")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "Missing required 'type' field in index config".to_string())?;
+
+    let distance_type = match cfg.get("distance_type").and_then(|v| v.as_str()) {
+        Some(dt) => Some(crate::query::parse_distance_type(dt).map_err(|e| e.to_string())?),
+        None => None,
+    };
+
+    // Strict u32 extractor: rejects values that exceed u32::MAX rather
+    // than silently truncating with `as u32` (which would map e.g.
+    // 4294967296 to 0 and quietly mistune the index).
+    let u32_opt = |k: &str| -> Result<Option<u32>, String> {
+        match cfg.get(k).and_then(|v| v.as_u64()) {
+            None => Ok(None),
+            Some(n) => u32::try_from(n)
+                .map(Some)
+                .map_err(|_| format!("'{}' value {} does not fit in u32", k, n)),
+        }
+    };
+    let bool_opt = |k: &str| -> Option<bool> { cfg.get(k).and_then(|v| v.as_bool()) };
+    let str_opt = |k: &str| -> Option<&str> { cfg.get(k).and_then(|v| v.as_str()) };
+
+    // Small macro-like helper: apply the set of IVF-common options.
+    macro_rules! apply_ivf_common {
+        ($b:ident, $set_distance:expr) => {{
+            if $set_distance {
+                if let Some(dt) = distance_type {
+                    $b = $b.distance_type(dt);
+                }
+            }
+            if let Some(n) = u32_opt("num_partitions")? {
+                $b = $b.num_partitions(n);
+            }
+            if let Some(n) = u32_opt("sample_rate")? {
+                $b = $b.sample_rate(n);
+            }
+            if let Some(n) = u32_opt("max_iterations")? {
+                $b = $b.max_iterations(n);
+            }
+            if let Some(n) = u32_opt("target_partition_size")? {
+                $b = $b.target_partition_size(n);
+            }
+        }};
+    }
+
+    match kind {
+        "ivf_pq" | "vector" => {
+            let mut b = IvfPqIndexBuilder::default();
+            apply_ivf_common!(b, true);
+            if let Some(n) = u32_opt("num_sub_vectors")? {
+                b = b.num_sub_vectors(n);
+            }
+            if let Some(n) = u32_opt("num_bits")? {
+                b = b.num_bits(n);
+            }
+            Ok(Index::IvfPq(b))
+        }
+        "ivf_flat" => {
+            let mut b = IvfFlatIndexBuilder::default();
+            apply_ivf_common!(b, true);
+            Ok(Index::IvfFlat(b))
+        }
+        "ivf_sq" => {
+            let mut b = IvfSqIndexBuilder::default();
+            apply_ivf_common!(b, true);
+            Ok(Index::IvfSq(b))
+        }
+        "ivf_rq" => {
+            let mut b = IvfRqIndexBuilder::default();
+            apply_ivf_common!(b, true);
+            if let Some(n) = u32_opt("num_bits")? {
+                b = b.num_bits(n);
+            }
+            Ok(Index::IvfRq(b))
+        }
+        "ivf_hnsw_pq" | "hnsw_pq" => {
+            let mut b = IvfHnswPqIndexBuilder::default();
+            apply_ivf_common!(b, true);
+            if let Some(m) = u32_opt("m")? {
+                b = b.num_edges(m);
+            }
+            if let Some(ef) = u32_opt("ef_construction")? {
+                b = b.ef_construction(ef);
+            }
+            if let Some(n) = u32_opt("num_sub_vectors")? {
+                b = b.num_sub_vectors(n);
+            }
+            if let Some(n) = u32_opt("num_bits")? {
+                b = b.num_bits(n);
+            }
+            Ok(Index::IvfHnswPq(b))
+        }
+        "ivf_hnsw_sq" | "hnsw_sq" => {
+            let mut b = IvfHnswSqIndexBuilder::default();
+            apply_ivf_common!(b, true);
+            if let Some(m) = u32_opt("m")? {
+                b = b.num_edges(m);
+            }
+            if let Some(ef) = u32_opt("ef_construction")? {
+                b = b.ef_construction(ef);
+            }
+            Ok(Index::IvfHnswSq(b))
+        }
+        "btree" => Ok(Index::BTree(BTreeIndexBuilder {})),
+        "bitmap" => Ok(Index::Bitmap(BitmapIndexBuilder {})),
+        "label_list" => Ok(Index::LabelList(LabelListIndexBuilder {})),
+        "fts" => {
+            let mut b = FtsIndexBuilder::default();
+            if let Some(s) = str_opt("language") {
+                b = b
+                    .language(s)
+                    .map_err(|e| format!("Invalid FTS language: {}", e))?;
+            }
+            if let Some(v) = bool_opt("with_position") {
+                b = b.with_position(v);
+            }
+            if let Some(v) = bool_opt("stem") {
+                b = b.stem(v);
+            }
+            if let Some(v) = bool_opt("remove_stop_words") {
+                b = b.remove_stop_words(v);
+            }
+            if let Some(v) = bool_opt("lower_case") {
+                b = b.lower_case(v);
+            }
+            if let Some(v) = bool_opt("ascii_folding") {
+                b = b.ascii_folding(v);
+            }
+            if let Some(s) = str_opt("base_tokenizer") {
+                b = b.base_tokenizer(s.to_string());
+            }
+            if let Some(n) = cfg.get("max_token_length").and_then(|v| v.as_u64()) {
+                let v = usize::try_from(n)
+                    .map_err(|_| format!("'max_token_length' value {} does not fit in usize", n))?;
+                b = b.max_token_length(Some(v));
+            }
+            if let Some(n) = u32_opt("ngram_min_length")? {
+                b = b.ngram_min_length(n);
+            }
+            if let Some(n) = u32_opt("ngram_max_length")? {
+                b = b.ngram_max_length(n);
+            }
+            if let Some(v) = bool_opt("ngram_prefix_only") {
+                b = b.ngram_prefix_only(v);
+            }
+            Ok(Index::FTS(b))
+        }
+        other => Err(format!("Unsupported index type: {}", other)),
+    }
+}
+
+/// Create an index with full tuning parameters. The `config_json` is the
+/// canonical surface for per-type tuning (num_partitions, m, ef_construction,
+/// FTS options, etc.); the small top-level knobs (name/replace/
+/// wait_timeout_ms) are passed as regular arguments so callers don't have to
+/// encode them into JSON just to change a single bool.
+///
+/// - `name` may be NULL for the backend default.
+/// - `replace` matches lancedb's IndexBuilder::replace (default true in
+///   upstream; we forward the caller's choice verbatim).
+/// - `wait_timeout_ms == 0` leaves the backend default (no wait).
+#[no_mangle]
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+pub extern "C" fn simple_lancedb_table_create_index_v2(
+    table_handle: *mut c_void,
+    columns_json: *const c_char,
+    config_json: *const c_char,
+    name: *const c_char,
+    replace: bool,
+    wait_timeout_ms: u64,
+) -> *mut SimpleResult {
+    let result = std::panic::catch_unwind(|| -> SimpleResult {
+        if table_handle.is_null() || columns_json.is_null() || config_json.is_null() {
+            return SimpleResult::error("Invalid null arguments".to_string());
+        }
+
+        let columns_str = match from_c_str(columns_json) {
+            Ok(s) => s,
+            Err(e) => return SimpleResult::error(format!("Invalid columns JSON: {}", e)),
+        };
+        let columns: Vec<String> = match serde_json::from_str(&columns_str) {
+            Ok(c) => c,
+            Err(e) => return SimpleResult::error(format!("Failed to parse columns JSON: {}", e)),
+        };
+
+        let cfg_str = match from_c_str(config_json) {
+            Ok(s) => s,
+            Err(e) => return SimpleResult::error(format!("Invalid config JSON: {}", e)),
+        };
+        let cfg: serde_json::Value = match serde_json::from_str(&cfg_str) {
+            Ok(v) => v,
+            Err(e) => return SimpleResult::error(format!("Failed to parse index config: {}", e)),
+        };
+
+        let name_owned: Option<String> = if name.is_null() {
+            None
+        } else {
+            match from_c_str(name) {
+                Ok(s) if s.is_empty() => None,
+                Ok(s) => Some(s),
+                Err(e) => return SimpleResult::error(format!("Invalid index name: {}", e)),
+            }
+        };
+
+        let index = match build_index_from_config(&cfg) {
+            Ok(i) => i,
+            Err(e) => return SimpleResult::error(e),
+        };
+
+        let table = unsafe { &*(table_handle as *const lancedb::Table) };
+        let rt = get_simple_runtime();
+
+        let outcome = rt.block_on(async {
+            let mut builder = table.create_index(&columns, index);
+            if let Some(n) = name_owned {
+                builder = builder.name(n);
+            }
+            builder = builder.replace(replace);
+            if wait_timeout_ms > 0 {
+                builder = builder.wait_timeout(Duration::from_millis(wait_timeout_ms));
+            }
+            builder.execute().await
+        });
+
+        match outcome {
+            Ok(_) => SimpleResult::ok(),
+            Err(e) => SimpleResult::error(format!("create_index_v2 failed: {}", e)),
+        }
+    });
+
+    match result {
+        Ok(res) => Box::into_raw(Box::new(res)),
+        Err(_) => Box::into_raw(Box::new(SimpleResult::error(
+            "Panic in simple_lancedb_table_create_index_v2".to_string(),
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Pin the u32_opt range check — silently truncating values above
+    // u32::MAX with `as u32` would mistune the index without surfacing
+    // an error (e.g. 4294967296 would become 0). The fix uses
+    // u32::try_from and returns a user-facing error.
+    #[test]
+    fn build_index_from_config_rejects_u32_overflow() {
+        let cfg = serde_json::json!({
+            "type": "ivf_pq",
+            // 2^32 — one above u32::MAX
+            "num_partitions": 4_294_967_296u64,
+        });
+        let err = build_index_from_config(&cfg)
+            .expect_err("u32-overflow num_partitions must fail, not silently truncate");
+        assert!(
+            err.contains("num_partitions") && err.contains("u32"),
+            "error should mention the offending field and the type, got: {}",
+            err
+        );
+    }
+
+    // u32::MAX exactly is the largest accepted value. Spot-check the
+    // boundary so the rewrite doesn't accidentally slide off-by-one.
+    #[test]
+    fn build_index_from_config_accepts_u32_max() {
+        let cfg = serde_json::json!({
+            "type": "ivf_pq",
+            "num_partitions": u32::MAX as u64,
+        });
+        let result = build_index_from_config(&cfg);
+        assert!(
+            result.is_ok(),
+            "u32::MAX should be accepted, got error: {:?}",
+            result.err()
+        );
+    }
+}

--- a/rust/src/query.rs
+++ b/rust/src/query.rs
@@ -21,12 +21,15 @@ fn parse_column_names(columns: &[serde_json::Value]) -> Vec<String> {
         .collect()
 }
 
-/// Parse a distance type string into a LanceDB DistanceType.
-fn parse_distance_type(dt: &str) -> Result<lancedb::DistanceType, lancedb::Error> {
+/// Parse a distance type string into a LanceDB DistanceType. Shared by the
+/// query path and the index path (rust/src/index.rs), which wraps any
+/// error into String via map_err.
+pub(crate) fn parse_distance_type(dt: &str) -> Result<lancedb::DistanceType, lancedb::Error> {
     match dt {
         "l2" => Ok(lancedb::DistanceType::L2),
         "cosine" => Ok(lancedb::DistanceType::Cosine),
         "dot" => Ok(lancedb::DistanceType::Dot),
+        "hamming" => Ok(lancedb::DistanceType::Hamming),
         other => Err(lancedb::Error::InvalidInput {
             message: format!("Unknown distance type: {}", other),
         }),


### PR DESCRIPTION
## Summary

Adds a second create-index entry point that mirrors lancedb::IndexBuilder's
full surface — per-type tuning, name, replace, wait_timeout — instead of
the existing CreateIndex / CreateIndexWithName, which only expose the
type and an optional name with backend defaults for everything else.

The existing two methods are left untouched for backward compatibility.

Rust FFI (`rust/src/index.rs`):
- New `simple_lancedb_table_create_index_v2` entry point.
- `build_index_from_config` parses the config JSON `type` field plus
  per-kind parameters into a `lancedb::index::Index` value.
- IVF common: num_partitions / sample_rate / max_iterations /
  target_partition_size / distance_type.
- PQ: num_sub_vectors / num_bits on IvfPq / IvfRq / IvfHnswPq.
- HNSW: m (num_edges) / ef_construction on IvfHnswPq / IvfHnswSq.
- FTS: language / with_position / stem / remove_stop_words / lower_case
  / ascii_folding / base_tokenizer / max_token_length /
  ngram_{min,max}_length / ngram_prefix_only.
- Top-level IndexBuilder.name / .replace / .wait_timeout forwarded.
- distance_type parsing reuses the existing `crate::query::parse_distance_type`
  (now `pub(crate)`) instead of a near-duplicate; the helper also gains
  `hamming` to match lancedb v0.24.0.

Go contracts:
- `IndexParams` struct with pointer fields so unset == backend default.
- `CreateIndexOptions { Name, Replace, WaitTimeout }`.
- `ITable.CreateIndexWithParams(ctx, columns, indexType, params, opts)`.

Go internal (`pkg/internal/table.go`):
- Marshals an envelope struct (`type` + `distance_type` + embedded
  IndexParams) in a single json.Marshal — no map round-trip — and forwards
  to the new FFI. `nil` opts is equivalent to zero-valued
  CreateIndexOptions.

Tests (`pkg/tests/create_index_v2_test.go`):
- IvfPq with num_partitions / num_sub_vectors / distance_type / name.
- HnswPq with m / ef_construction.
- FTS with tokenizer options.
- Replace=false duplicate fails, Replace=true succeeds.
- nil opts is accepted.

Example (`examples/index_builder/`): IVF_PQ + IVF_HNSW_PQ + FTS with
tuning, plus Makefile target.

C header regenerated by cbindgen.

## Series context

This is **PR 3 of 5** in the series introduced in #29 (merged) and #30
(merged). The roadmap is documented in #29. Remaining PRs land
sequentially:

- **#29 ✅ merged** — per-query vector tuning
- **#30 ✅ merged** — Table::wait_for_index
- **this PR** — create_index_v2 (full IVF / HNSW / FTS tuning + name / replace / wait_timeout)
- **next** — RRF reranker wiring
- **finally** — hybrid vector + FTS search via WithFullText