### PR TITLE
feat: expose RRF reranker through the query config

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -166,6 +166,12 @@ index-builder: check-libraries
 	@cd index_builder && \
 	CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" go run index_builder.go
 
+reranker: check-libraries
+	@echo "🚀 Running Reranker (RRF) example..."
+	@echo "Platform: $(PLATFORM_ARCH)"
+	@cd reranker && \
+	CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" go run reranker.go
+
 # Build all examples (without running)
 build-all: check-libraries
 	@echo "🔨 Building all examples for $(PLATFORM_ARCH)..."

--- a/examples/reranker/reranker.go
+++ b/examples/reranker/reranker.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The LanceDB Authors
+
+// Reranker (RRF) example.
+//
+// Demonstrates attaching an RRF reranker to a query. Reranking only has
+// observable effect when the query has two score channels to fuse — the
+// hybrid search example (examples/hybrid_search) shows that combination.
+// This example focuses on the API surface: how to pick a k value and a
+// normalization method.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/array"
+	"github.com/apache/arrow/go/v17/arrow/memory"
+
+	"github.com/lancedb/lancedb-go/pkg/contracts"
+	"github.com/lancedb/lancedb-go/pkg/lancedb"
+)
+
+const dim = 64
+
+func main() {
+	fmt.Println("🚀 LanceDB Go SDK - Reranker (RRF) Example")
+	fmt.Println("===========================================")
+
+	ctx := context.Background()
+	tempDir, err := os.MkdirTemp("", "lancedb_reranker_example_")
+	if err != nil {
+		log.Fatalf("temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	conn, err := lancedb.Connect(ctx, tempDir, nil)
+	if err != nil {
+		log.Fatalf("connect: %v", err)
+	}
+	defer conn.Close()
+
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
+		{Name: "embedding", Type: arrow.FixedSizeListOf(dim, arrow.PrimitiveTypes.Float32), Nullable: false},
+	}, nil)
+	schema, err := lancedb.NewSchema(arrowSchema)
+	if err != nil {
+		log.Fatalf("schema: %v", err)
+	}
+	table, err := conn.CreateTable(ctx, "docs", schema)
+	if err != nil {
+		log.Fatalf("create table: %v", err)
+	}
+	defer table.Close()
+
+	const n = 100
+	pool := memory.NewGoAllocator()
+	idB := array.NewInt32Builder(pool)
+	embB := array.NewFixedSizeListBuilder(pool, dim, arrow.PrimitiveTypes.Float32)
+	embValB := embB.ValueBuilder().(*array.Float32Builder)
+	for i := 0; i < n; i++ {
+		idB.Append(int32(i))
+		embB.Append(true)
+		for j := 0; j < dim; j++ {
+			embValB.Append(float32(i)*0.01 + float32(j)*0.001)
+		}
+	}
+	rec := array.NewRecord(arrowSchema, []arrow.Array{idB.NewArray(), embB.NewArray()}, n)
+	defer rec.Release()
+	if err := table.Add(ctx, rec, nil); err != nil {
+		log.Fatalf("add: %v", err)
+	}
+
+	queryVec := make([]float32, dim)
+	for j := 0; j < dim; j++ {
+		queryVec[j] = 0.5 + float32(j)*0.001
+	}
+
+	fmt.Println("\n▶ Vector query + RRF reranker (k=60, norm=Rank)")
+	out, err := table.VectorQuery("embedding", queryVec).
+		Rerank(contracts.RerankerConfig{
+			Kind: contracts.RerankerRRF,
+			RRFK: 60,
+			Norm: contracts.NormalizeRank,
+		}).
+		Limit(5).
+		Execute(ctx)
+	if err != nil {
+		log.Fatalf("query: %v", err)
+	}
+	fmt.Printf("  returned %d rows\n", out.NumRows())
+	out.Release()
+
+	fmt.Println("\n▶ Default K (backend default = 60.0)")
+	out, err = table.VectorQuery("embedding", queryVec).
+		Rerank(contracts.RerankerConfig{Kind: contracts.RerankerRRF}).
+		Limit(5).
+		Execute(ctx)
+	if err != nil {
+		log.Fatalf("query default k: %v", err)
+	}
+	fmt.Printf("  returned %d rows\n", out.NumRows())
+	out.Release()
+
+	fmt.Println("\n✅ Reranker example complete")
+	fmt.Println("   Try combining with hybrid search (vector + FTS) to see")
+	fmt.Println("   actual rerank behaviour across two score channels.")
+}

--- a/pkg/contracts/i_query.go
+++ b/pkg/contracts/i_query.go
@@ -20,6 +20,10 @@ type IQueryBuilder interface {
 	FastSearch() IQueryBuilder
 	// Postfilter evaluates WHERE after the candidate set is built.
 	Postfilter() IQueryBuilder
+	// Rerank installs a reranker on the query. Most useful in hybrid
+	// search where vector and FTS scores need to be fused; on a single
+	// channel the backend may noop.
+	Rerank(cfg RerankerConfig) IQueryBuilder
 	Execute(ctx context.Context) (arrow.Record, error)
 	ExecuteAsync(ctx context.Context) (<-chan arrow.Record, <-chan error)
 	ApplyOptions(options *QueryOptions) IQueryBuilder
@@ -44,6 +48,9 @@ type IVectorQueryBuilder interface {
 	FastSearch() IVectorQueryBuilder
 	// Postfilter evaluates WHERE after the vector candidate set is built.
 	Postfilter() IVectorQueryBuilder
+	// Rerank installs a reranker on the query. Most useful in hybrid
+	// search where vector and FTS scores need to be fused.
+	Rerank(cfg RerankerConfig) IVectorQueryBuilder
 	Execute(ctx context.Context) (arrow.Record, error)
 	ExecuteAsync(ctx context.Context) (<-chan arrow.Record, <-chan error)
 	ApplyOptions(options *QueryOptions) IVectorQueryBuilder

--- a/pkg/contracts/types.go
+++ b/pkg/contracts/types.go
@@ -1,6 +1,9 @@
 package contracts
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+)
 
 // IndexType represents the type of index to create
 type IndexType int
@@ -82,6 +85,73 @@ type CreateIndexOptions struct {
 	WaitTimeout time.Duration
 }
 
+// RerankerKind identifies the reranker to apply to a query's results. The
+// upstream lancedb v0.24.0 ships RRF as its only built-in; this enum
+// leaves room for future kinds without breaking callers.
+type RerankerKind int
+
+const (
+	// RerankerNone leaves the query un-reranked.
+	RerankerNone RerankerKind = iota
+	// RerankerRRF is Reciprocal Rank Fusion. Good default for hybrid
+	// vector+FTS queries.
+	RerankerRRF
+)
+
+// NormalizeMethod maps to lancedb::rerankers::NormalizeMethod. Controls
+// how the reranker combines scores across modalities.
+type NormalizeMethod int
+
+const (
+	// NormalizeDefault leaves the reranker's own default behaviour.
+	NormalizeDefault NormalizeMethod = iota
+	// NormalizeScore normalises by raw score.
+	NormalizeScore
+	// NormalizeRank normalises by rank (typical for RRF).
+	NormalizeRank
+)
+
+// RerankerConfig describes how to rerank query results. Kind selects the
+// reranker; the remaining fields are per-kind. Leave RerankerNone to skip
+// reranking.
+type RerankerConfig struct {
+	Kind RerankerKind
+	// RRFK maps to lancedb::rerankers::RRFReranker::new(k). Defaults to
+	// 60.0 when zero and Kind == RerankerRRF (matches upstream).
+	RRFK float32
+	// Norm sets the normalization method for the reranker.
+	Norm NormalizeMethod
+}
+
+// MarshalJSON emits the wire shape consumed by the Rust FFI
+// ({"kind":"rrf","k":...,"norm":...}). RerankerNone marshals to null so
+// omitempty on the parent field drops the section entirely.
+func (rc *RerankerConfig) MarshalJSON() ([]byte, error) {
+	if rc == nil || rc.Kind == RerankerNone {
+		return []byte("null"), nil
+	}
+	var wire struct {
+		Kind string   `json:"kind"`
+		K    *float32 `json:"k,omitempty"`
+		Norm string   `json:"norm,omitempty"`
+	}
+	switch rc.Kind {
+	case RerankerRRF:
+		wire.Kind = "rrf"
+	}
+	if rc.RRFK > 0 {
+		k := rc.RRFK
+		wire.K = &k
+	}
+	switch rc.Norm {
+	case NormalizeScore:
+		wire.Norm = "score"
+	case NormalizeRank:
+		wire.Norm = "rank"
+	}
+	return json.Marshal(wire)
+}
+
 // IndexStatistics represents statistics about an index
 type IndexStatistics struct {
 	NumIndexedRows   int64    `json:"num_indexed_rows"`
@@ -111,6 +181,11 @@ type QueryConfig struct {
 	// candidate set is materialised. Default is prefilter. Maps to
 	// QueryBase::postfilter().
 	Postfilter bool `json:"postfilter,omitempty"`
+
+	// Reranker attaches a reranker to the query. Nil leaves the backend
+	// default (no reranker on single-channel queries; automatic RRF on
+	// hybrid nearest_to + full_text_search queries).
+	Reranker *RerankerConfig `json:"reranker,omitempty"`
 }
 
 // VectorSearch represents vector similarity search parameters

--- a/pkg/internal/query.go
+++ b/pkg/internal/query.go
@@ -23,6 +23,7 @@ type QueryBuilder struct {
 	withRowID  bool
 	fastSearch bool
 	postfilter bool
+	reranker   *lancedb.RerankerConfig
 }
 
 var _ lancedb.IQueryBuilder = (*QueryBuilder)(nil)
@@ -80,6 +81,13 @@ func (q *QueryBuilder) FastSearch() lancedb.IQueryBuilder {
 // Postfilter evaluates WHERE after the candidate set is built.
 func (q *QueryBuilder) Postfilter() lancedb.IQueryBuilder {
 	q.postfilter = true
+	return q
+}
+
+// Rerank installs a reranker on the query.
+func (q *QueryBuilder) Rerank(cfg lancedb.RerankerConfig) lancedb.IQueryBuilder {
+	c := cfg
+	q.reranker = &c
 	return q
 }
 
@@ -163,6 +171,10 @@ func (q *QueryBuilder) buildConfig() lancedb.QueryConfig {
 	config.WithRowID = q.withRowID
 	config.FastSearch = q.fastSearch
 	config.Postfilter = q.postfilter
+	if q.reranker != nil && q.reranker.Kind != lancedb.RerankerNone {
+		rc := *q.reranker
+		config.Reranker = &rc
+	}
 
 	return config
 }
@@ -255,6 +267,13 @@ func (vq *VectorQueryBuilder) FastSearch() lancedb.IVectorQueryBuilder {
 // Postfilter evaluates WHERE after the vector candidate set is built.
 func (vq *VectorQueryBuilder) Postfilter() lancedb.IVectorQueryBuilder {
 	vq.QueryBuilder.postfilter = true
+	return vq
+}
+
+// Rerank installs a reranker on the vector query.
+func (vq *VectorQueryBuilder) Rerank(cfg lancedb.RerankerConfig) lancedb.IVectorQueryBuilder {
+	c := cfg
+	vq.QueryBuilder.reranker = &c
 	return vq
 }
 

--- a/pkg/tests/reranker_test.go
+++ b/pkg/tests/reranker_test.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The LanceDB Authors
+
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/lancedb/lancedb-go/pkg/contracts"
+)
+
+// These tests focus on the wire-up of RerankerConfig through the Go builder
+// and into the Rust FFI. Observable reranker effects are tested under PR E
+// (hybrid search), which actually combines vector + FTS scores; PR D's job
+// is to ensure an RRF configuration travels end-to-end without error and
+// unknown kinds / norms surface as user-facing errors.
+
+// TestVectorQuery_Rerank_RRF_DoesNotError — smoke test: vector-only query
+// with an RRF reranker attached must still execute. Reranker is a no-op
+// here because there's no second channel, but the wiring (Go builder →
+// QueryConfig.Reranker → JSON → Rust parse → QueryBase::rerank) must be
+// error-free.
+func TestVectorQuery_Rerank_RRF_DoesNotError(t *testing.T) {
+	table, cleanup := setupVectorQueryTestTable(t)
+	defer cleanup()
+
+	queryVec := make([]float32, 128)
+	for i := 0; i < 128; i++ {
+		queryVec[i] = 0.1 + float32(i)*0.001
+	}
+
+	rec, err := table.VectorQuery("embedding", queryVec).
+		Rerank(contracts.RerankerConfig{
+			Kind: contracts.RerankerRRF,
+			RRFK: 30,
+			Norm: contracts.NormalizeRank,
+		}).
+		Limit(5).
+		Execute(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, rec)
+	rec.Release()
+}
+
+// TestVectorQuery_Rerank_DefaultK_UsesBackendDefault — K==0 must omit the
+// k field from JSON, letting the Rust side fall back to RRFReranker's own
+// default (60.0).
+func TestVectorQuery_Rerank_DefaultK_UsesBackendDefault(t *testing.T) {
+	table, cleanup := setupVectorQueryTestTable(t)
+	defer cleanup()
+
+	queryVec := make([]float32, 128)
+	rec, err := table.VectorQuery("embedding", queryVec).
+		Rerank(contracts.RerankerConfig{Kind: contracts.RerankerRRF}).
+		Limit(3).
+		Execute(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, rec)
+	rec.Release()
+}
+
+// TestQuery_Rerank_RRF_Standard — the reranker wiring also reaches the
+// non-vector query path (currently a no-op backend-side, but the JSON must
+// still parse cleanly).
+func TestQuery_Rerank_RRF_Standard(t *testing.T) {
+	table, cleanup := setupQueryTestTable(t)
+	defer cleanup()
+
+	rec, err := table.Query().
+		Rerank(contracts.RerankerConfig{Kind: contracts.RerankerRRF, RRFK: 60}).
+		Limit(5).
+		Execute(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, rec)
+	rec.Release()
+}
+
+// TestSelect_RerankerNone_DirectQueryConfig — Strategy 1 (Edge): a user
+// who hand-builds QueryConfig with Reranker: &RerankerConfig{} (i.e.
+// Kind == RerankerNone) used to surface as "reranker": null in the
+// wire JSON, which the Rust parser treated as a missing kind and
+// rejected. Pin the no-op behaviour so direct QueryConfig users don't
+// get a spurious error.
+func TestSelect_RerankerNone_DirectQueryConfig(t *testing.T) {
+	table, cleanup := setupQueryTestTable(t)
+	defer cleanup()
+
+	limit := 3
+	rows, err := table.Select(context.Background(), contracts.QueryConfig{
+		Limit:    &limit,
+		Reranker: &contracts.RerankerConfig{Kind: contracts.RerankerNone},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, rows)
+}
+
+// TestVectorQuery_Rerank_Norm_ScoreAndRank — both NormalizeMethod values
+// must be accepted by the Rust parser.
+func TestVectorQuery_Rerank_Norm_ScoreAndRank(t *testing.T) {
+	cases := []contracts.NormalizeMethod{
+		contracts.NormalizeDefault,
+		contracts.NormalizeScore,
+		contracts.NormalizeRank,
+	}
+	for _, n := range cases {
+		n := n
+		t.Run("norm", func(t *testing.T) {
+			table, cleanup := setupVectorQueryTestTable(t)
+			defer cleanup()
+
+			queryVec := make([]float32, 128)
+			rec, err := table.VectorQuery("embedding", queryVec).
+				Rerank(contracts.RerankerConfig{Kind: contracts.RerankerRRF, Norm: n}).
+				Limit(3).
+				Execute(context.Background())
+			require.NoError(t, err)
+			require.NotNil(t, rec)
+			rec.Release()
+		})
+	}
+}

--- a/rust/src/query.rs
+++ b/rust/src/query.rs
@@ -8,8 +8,11 @@ use crate::ffi::{from_c_str, SimpleResult};
 use crate::runtime::get_simple_runtime;
 use lancedb::index::scalar::FullTextSearchQuery;
 use lancedb::query::{ExecutableQuery, QueryBase};
+use lancedb::rerankers::rrf::RRFReranker;
+use lancedb::rerankers::{NormalizeMethod, Reranker};
 use std::ffi::CString;
 use std::os::raw::{c_char, c_void};
+use std::sync::Arc;
 use tokio_stream::StreamExt;
 
 /// Parse a JSON array of column name strings.
@@ -36,10 +39,73 @@ pub(crate) fn parse_distance_type(dt: &str) -> Result<lancedb::DistanceType, lan
     }
 }
 
-/// Apply top-level QueryBase flags (with_row_id, fast_search, postfilter)
-/// to any builder that implements QueryBase. Shared by the vector, FTS,
-/// and standard query paths.
-pub(crate) fn apply_query_base_flags<Q: QueryBase>(mut q: Q, config: &serde_json::Value) -> Q {
+/// Default RRF k parameter. Matches lancedb::rerankers::rrf::RRFReranker's
+/// own default so an omitted k produces identical behaviour.
+const DEFAULT_RRF_K: f32 = 60.0;
+
+/// Result type for parse_reranker. Pulled out to tame clippy::type_complexity.
+type RerankerParse = (Option<Arc<dyn Reranker>>, Option<NormalizeMethod>);
+
+/// Parse the top-level `reranker` / `norm` section of a query config.
+/// Returns Ok((None, None)) as the fast path when no reranker is
+/// configured — the only cost in that case is a single map lookup.
+fn parse_reranker(config: &serde_json::Value) -> Result<RerankerParse, lancedb::Error> {
+    let Some(reranker_cfg) = config.get("reranker") else {
+        return Ok((None, None));
+    };
+    // Treat an explicit null the same as a missing key. Go's omitempty
+    // can't drop a non-nil *RerankerConfig pointer, so callers who pass
+    // QueryConfig{Reranker: &RerankerConfig{Kind: RerankerNone}} land
+    // here with `null` — that's intent to skip reranking, not an error.
+    if reranker_cfg.is_null() {
+        return Ok((None, None));
+    }
+
+    let kind = reranker_cfg
+        .get("kind")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| lancedb::Error::InvalidInput {
+            message: "reranker requires a 'kind' field".to_string(),
+        })?;
+
+    let reranker: Arc<dyn Reranker> = match kind {
+        "rrf" => {
+            let k = reranker_cfg
+                .get("k")
+                .and_then(|v| v.as_f64())
+                .map(|v| v as f32)
+                .unwrap_or(DEFAULT_RRF_K);
+            Arc::new(RRFReranker::new(k))
+        }
+        other => {
+            return Err(lancedb::Error::InvalidInput {
+                message: format!("Unknown reranker kind: {}", other),
+            })
+        }
+    };
+
+    let norm = match reranker_cfg.get("norm").and_then(|v| v.as_str()) {
+        Some("rank") => Some(NormalizeMethod::Rank),
+        Some("score") => Some(NormalizeMethod::Score),
+        Some(other) => {
+            return Err(lancedb::Error::InvalidInput {
+                message: format!("Unknown reranker norm method: {}", other),
+            })
+        }
+        None => None,
+    };
+
+    Ok((Some(reranker), norm))
+}
+
+/// Apply top-level QueryBase flags (with_row_id, fast_search, postfilter,
+/// reranker, norm) to any builder implementing lancedb's QueryBase trait.
+/// Shared by the vector, FTS, and standard query paths — all three use
+/// VectorQuery or Query which both implement QueryBase.
+pub(crate) fn apply_query_base_flags<Q: QueryBase>(
+    mut q: Q,
+    config: &serde_json::Value,
+) -> Result<Q, lancedb::Error> {
     if config
         .get("with_row_id")
         .and_then(|v| v.as_bool())
@@ -61,7 +127,14 @@ pub(crate) fn apply_query_base_flags<Q: QueryBase>(mut q: Q, config: &serde_json
     {
         q = q.postfilter();
     }
-    q
+    let (reranker, norm) = parse_reranker(config)?;
+    if let Some(r) = reranker {
+        q = q.rerank(r);
+    }
+    if let Some(n) = norm {
+        q = q.norm(n);
+    }
+    Ok(q)
 }
 
 /// Build and execute a query from JSON config, returning a record batch stream.
@@ -141,7 +214,7 @@ async fn execute_query_from_config(
                         vector_query = vector_query.bypass_vector_index();
                     }
 
-                    vector_query = apply_query_base_flags(vector_query, query_config);
+                    vector_query = apply_query_base_flags(vector_query, query_config)?;
 
                     return vector_query.execute().await;
                 }
@@ -198,7 +271,7 @@ async fn execute_query_from_config(
             });
         }
 
-        fts_query = apply_query_base_flags(fts_query, query_config);
+        fts_query = apply_query_base_flags(fts_query, query_config)?;
 
         return fts_query.execute().await;
     }
@@ -225,7 +298,7 @@ async fn execute_query_from_config(
         query = query.only_if(filter);
     }
 
-    query = apply_query_base_flags(query, query_config);
+    query = apply_query_base_flags(query, query_config)?;
 
     query.execute().await
 }
@@ -442,5 +515,33 @@ pub extern "C" fn simple_lancedb_table_select_query_ipc(
         Err(_) => Box::into_raw(Box::new(SimpleResult::error(
             "Panic in simple_lancedb_table_select_query_ipc".to_string(),
         ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Both a missing reranker key and an explicit null must be treated
+    // as "no reranker configured". Go's omitempty cannot drop a non-nil
+    // *RerankerConfig pointer, so users who hand-build QueryConfig with
+    // RerankerNone end up sending the null form.
+    #[test]
+    fn parse_reranker_treats_missing_and_null_as_none() {
+        let no_key = serde_json::json!({});
+        let (r, n) = parse_reranker(&no_key).unwrap();
+        assert!(r.is_none() && n.is_none(), "missing reranker key");
+
+        let null = serde_json::json!({"reranker": null});
+        let (r, n) = parse_reranker(&null).unwrap();
+        assert!(r.is_none() && n.is_none(), "explicit null reranker");
+    }
+
+    #[test]
+    fn parse_reranker_rejects_unknown_kind() {
+        let bad = serde_json::json!({"reranker": {"kind": "what"}});
+        let err = parse_reranker(&bad).expect_err("unknown kind must error");
+        let msg = err.to_string();
+        assert!(msg.contains("Unknown reranker kind"), "got: {}", msg);
     }
 }


### PR DESCRIPTION
## Summary

Wires lancedb's RRF reranker through the existing select_query_ipc FFI
via a new `reranker` section on the query config JSON. No new FFI
entry point.

The reranker has observable effect on hybrid queries (vector + FTS); on
a single-channel query the backend is a no-op. This PR establishes the
wire-up; hybrid search lands in the follow-up PR.

Rust FFI (`rust/src/query.rs`):
- `parse_reranker` turns
    `{"reranker": {"kind":"rrf","k":60.0,"norm":"rank"|"score"}}`
  into `(Arc<dyn Reranker>, NormalizeMethod)`. Fast-path returns
  `(None, None)` on the missing-key case so vector-only queries pay
  only one map lookup.
- `apply_query_base_flags<Q: QueryBase>` (already generic in the
  per-query-tuning PR) gains reranker/norm chaining and surfaces unknown
  kind/norm values as `InvalidInput` errors instead of silently dropping.
- `DEFAULT_RRF_K = 60.0` matches `RRFReranker::default()`.
- Only `rrf` is accepted at this layer; upstream lancedb v0.24.0 has no
  other built-in reranker.

Go contracts:
- `RerankerKind` (`RerankerNone`, `RerankerRRF`).
- `NormalizeMethod` (`NormalizeDefault`, `NormalizeScore`, `NormalizeRank`).
- `RerankerConfig { Kind, RRFK, Norm }` with a `MarshalJSON` that emits the
  Rust wire shape directly — no separate wire-format type leaks into the
  public surface.
- `IQueryBuilder.Rerank` and `IVectorQueryBuilder.Rerank` chaining methods.
- `QueryConfig.Reranker *RerankerConfig` (omitempty).

Go internal (`pkg/internal/query.go`):
- `QueryBuilder.reranker` field; `Rerank()` stores a copy so later edits
  to the passed-in config don't mutate the builder.
- `buildConfig` emits the reranker section when non-nil and not RerankerNone;
  RerankerConfig.MarshalJSON handles the rest.

Tests (`pkg/tests/reranker_test.go`):
- Vector query with RRF reranker executes cleanly.
- Default K (0) falls through to RRFReranker's backend default of 60.
- Reranker on the standard (non-vector) query path also passes.
- All three NormalizeMethod values are accepted.

Example (`examples/reranker/`): RRF with explicit k and norm, plus the
default-k variant. Notes that hybrid search (next PR) is where reranking
actually earns its keep.

Out of scope: LinearCombinationReranker, CohereReranker, CrossEncoderReranker
are not in upstream v0.24.0 and would require Rust-side implementations.

## Series context

This is **PR 4 of 5** in the series introduced in #29. Roadmap:

- **#29 ✅ merged** — per-query vector tuning
- **#30 ✅ merged** — Table::wait_for_index
- **#31 ✅ merged** — create_index_v2 with full IVF/HNSW/FTS tuning
- **this PR** — RRF reranker wiring
- **next** — hybrid vector + FTS search via WithFullText (depends on this PR's reranker config)