### PR TITLE
feat: hybrid vector + full-text search on VectorQuery

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -172,6 +172,12 @@ reranker: check-libraries
 	@cd reranker && \
 	CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" go run reranker.go
 
+hybrid-vector-fts: check-libraries
+	@echo "🚀 Running Hybrid (vector + FTS) Search example..."
+	@echo "Platform: $(PLATFORM_ARCH)"
+	@cd hybrid_vector_fts && \
+	CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" go run hybrid_vector_fts.go
+
 # Build all examples (without running)
 build-all: check-libraries
 	@echo "🔨 Building all examples for $(PLATFORM_ARCH)..."

--- a/examples/hybrid_vector_fts/hybrid_vector_fts.go
+++ b/examples/hybrid_vector_fts/hybrid_vector_fts.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The LanceDB Authors
+
+// Hybrid (vector + FTS) search example.
+//
+// Demonstrates true hybrid search: a single query that runs both a dense
+// vector nearest-neighbour pass and a BM25-style full-text-search pass,
+// then fuses the two rankings with RRF (Reciprocal Rank Fusion).
+//
+// This is distinct from the older "hybrid_search" example in this repo,
+// which combines vector search with SQL metadata filtering on the same
+// channel. Here we genuinely fuse two score channels.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/array"
+	"github.com/apache/arrow/go/v17/arrow/memory"
+
+	"github.com/lancedb/lancedb-go/pkg/contracts"
+	"github.com/lancedb/lancedb-go/pkg/lancedb"
+)
+
+const dim = 64
+
+func main() {
+	fmt.Println("🚀 LanceDB Go SDK - Hybrid (Vector + FTS) Search Example")
+	fmt.Println("=========================================================")
+
+	ctx := context.Background()
+	tempDir, err := os.MkdirTemp("", "lancedb_hybrid_vec_fts_example_")
+	if err != nil {
+		log.Fatalf("temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	conn, err := lancedb.Connect(ctx, tempDir, nil)
+	if err != nil {
+		log.Fatalf("connect: %v", err)
+	}
+	defer conn.Close()
+
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
+		{Name: "body", Type: arrow.BinaryTypes.String, Nullable: false},
+		{Name: "embedding", Type: arrow.FixedSizeListOf(dim, arrow.PrimitiveTypes.Float32), Nullable: false},
+	}, nil)
+	schema, err := lancedb.NewSchema(arrowSchema)
+	if err != nil {
+		log.Fatalf("schema: %v", err)
+	}
+	table, err := conn.CreateTable(ctx, "docs", schema)
+	if err != nil {
+		log.Fatalf("create table: %v", err)
+	}
+	defer table.Close()
+
+	docs := []string{
+		"the quick brown fox jumps over the lazy dog",
+		"a slow blue cat sleeps on the warm mat",
+		"fast green turtle swims through the clear river",
+		"an orange bird sings in the tall oak tree",
+		"the red fox hunts under the moonlit night",
+		"lancedb makes fast vector search feel ordinary",
+	}
+
+	const n = 200
+	pool := memory.NewGoAllocator()
+	idB := array.NewInt32Builder(pool)
+	bodyB := array.NewStringBuilder(pool)
+	embB := array.NewFixedSizeListBuilder(pool, dim, arrow.PrimitiveTypes.Float32)
+	embValB := embB.ValueBuilder().(*array.Float32Builder)
+	for i := 0; i < n; i++ {
+		idB.Append(int32(i))
+		bodyB.Append(docs[i%len(docs)])
+		embB.Append(true)
+		for j := 0; j < dim; j++ {
+			embValB.Append(float32(i)*0.01 + float32(j)*0.001)
+		}
+	}
+	rec := array.NewRecord(arrowSchema, []arrow.Array{idB.NewArray(), bodyB.NewArray(), embB.NewArray()}, n)
+	defer rec.Release()
+	if err := table.Add(ctx, rec, nil); err != nil {
+		log.Fatalf("add: %v", err)
+	}
+
+	// Hybrid search needs an FTS index on the text column.
+	fmt.Println("\n▶ Creating FTS index on body column")
+	if err := table.CreateIndexWithParams(
+		ctx,
+		[]string{"body"},
+		contracts.IndexTypeFts,
+		contracts.IndexParams{},
+		&contracts.CreateIndexOptions{Name: "body_fts", WaitTimeout: 60 * time.Second},
+	); err != nil {
+		log.Fatalf("create fts: %v", err)
+	}
+	fmt.Println("  ✓ FTS ready")
+
+	query := make([]float32, dim)
+	for j := 0; j < dim; j++ {
+		query[j] = 0.5 + float32(j)*0.001
+	}
+
+	fmt.Println("\n▶ Hybrid search (vector + FTS, default RRF reranker)")
+	out, err := table.VectorQuery("embedding", query).
+		WithFullText("brown fox", "body").
+		Limit(5).
+		Execute(ctx)
+	if err != nil {
+		log.Fatalf("hybrid: %v", err)
+	}
+	fmt.Printf("  returned %d rows, columns: ", out.NumRows())
+	for _, f := range out.Schema().Fields() {
+		fmt.Printf("%s ", f.Name)
+	}
+	fmt.Println()
+	out.Release()
+
+	fmt.Println("\n▶ Hybrid search with explicit RRF (k=30, norm=Rank)")
+	out, err = table.VectorQuery("embedding", query).
+		WithFullText("green turtle", "body").
+		Rerank(contracts.RerankerConfig{
+			Kind: contracts.RerankerRRF,
+			RRFK: 30,
+			Norm: contracts.NormalizeRank,
+		}).
+		Limit(5).
+		Execute(ctx)
+	if err != nil {
+		log.Fatalf("hybrid rrf: %v", err)
+	}
+	fmt.Printf("  returned %d rows\n", out.NumRows())
+	out.Release()
+
+	fmt.Println("\n✅ Hybrid (vector + FTS) example complete")
+}

--- a/pkg/contracts/i_query.go
+++ b/pkg/contracts/i_query.go
@@ -51,6 +51,11 @@ type IVectorQueryBuilder interface {
 	// Rerank installs a reranker on the query. Most useful in hybrid
 	// search where vector and FTS scores need to be fused.
 	Rerank(cfg RerankerConfig) IVectorQueryBuilder
+	// WithFullText turns the vector query into a hybrid vector+FTS
+	// query. The matching text column must have an FTS index.
+	// `column` may be empty to let lancedb pick the one indexed FTS
+	// column on the table.
+	WithFullText(query, column string) IVectorQueryBuilder
 	Execute(ctx context.Context) (arrow.Record, error)
 	ExecuteAsync(ctx context.Context) (<-chan arrow.Record, <-chan error)
 	ApplyOptions(options *QueryOptions) IVectorQueryBuilder

--- a/pkg/contracts/types.go
+++ b/pkg/contracts/types.go
@@ -207,6 +207,16 @@ type VectorSearch struct {
 	// BypassVectorIndex forces a flat (exhaustive) scan instead of the
 	// trained index. Maps to VectorQuery::bypass_vector_index().
 	BypassVectorIndex bool `json:"bypass_vector_index,omitempty"`
+
+	// FullTextQuery, when non-empty alongside Vector, turns the query
+	// into a hybrid search: lancedb runs both the dense nearest_to and
+	// an FTS pass and fuses the results with the configured reranker
+	// (RRF by default). The table must have an FTS index on the
+	// matching text column; use CreateIndexWithParams(FTS, ...) first.
+	FullTextQuery string `json:"full_text_query,omitempty"`
+	// FullTextColumn optionally pins the FTS column. Empty lets lancedb
+	// pick the one FTS-indexed column on the table.
+	FullTextColumn string `json:"full_text_column,omitempty"`
 }
 
 // FTSSearch represents full-text search parameters

--- a/pkg/internal/query.go
+++ b/pkg/internal/query.go
@@ -40,6 +40,8 @@ type VectorQueryBuilder struct {
 	refineFactor      *uint32
 	ef                *int
 	bypassVectorIndex bool
+	fullTextQuery     string
+	fullTextColumn    string
 }
 
 // Filter adds a filter condition to the query
@@ -277,6 +279,24 @@ func (vq *VectorQueryBuilder) Rerank(cfg lancedb.RerankerConfig) lancedb.IVector
 	return vq
 }
 
+// WithFullText turns the vector query into a hybrid vector+FTS query.
+// `column` may be empty to let lancedb pick the FTS-indexed column.
+//
+// `query` is trimmed; whitespace-only input is treated the same as the
+// empty string and falls back to a pure vector search (matches the
+// Rust-side guard that protects FullTextSearchQuery::new from an empty
+// tokenizer result).
+//
+// VectorQueryBuilder is single-use: calling Execute consumes the
+// configured state. Reusing a builder after Execute keeps any prior
+// WithFullText / Nprobes / etc. intact, which is rarely the intent;
+// build a fresh VectorQuery for each call site.
+func (vq *VectorQueryBuilder) WithFullText(query, column string) lancedb.IVectorQueryBuilder {
+	vq.fullTextQuery = strings.TrimSpace(query)
+	vq.fullTextColumn = column
+	return vq
+}
+
 // Execute executes the vector search query and returns results.
 // Delegates to Table.SelectIPC() which holds the mutex and checks closed state.
 func (vq *VectorQueryBuilder) Execute(ctx context.Context) (arrow.Record, error) {
@@ -317,6 +337,8 @@ func (vq *VectorQueryBuilder) Execute(ctx context.Context) (arrow.Record, error)
 	config.VectorSearch.RefineFactor = vq.refineFactor
 	config.VectorSearch.Ef = vq.ef
 	config.VectorSearch.BypassVectorIndex = vq.bypassVectorIndex
+	config.VectorSearch.FullTextQuery = vq.fullTextQuery
+	config.VectorSearch.FullTextColumn = vq.fullTextColumn
 
 	ipcBytes, err := vq.table.SelectIPC(ctx, config)
 	if err != nil {

--- a/pkg/tests/hybrid_search_test.go
+++ b/pkg/tests/hybrid_search_test.go
@@ -1,0 +1,296 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The LanceDB Authors
+
+package tests
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/array"
+	"github.com/apache/arrow/go/v17/arrow/memory"
+	"github.com/stretchr/testify/require"
+
+	"github.com/lancedb/lancedb-go/pkg/contracts"
+	"github.com/lancedb/lancedb-go/pkg/internal"
+	"github.com/lancedb/lancedb-go/pkg/lancedb"
+)
+
+// setupHybridSearchTable builds a table with both a vector and a text
+// column, seeds rows, and creates an FTS index on the text column so
+// WithFullText() has the index it needs. Returns the populated table.
+func setupHybridSearchTable(t *testing.T) (*internal.Table, func()) {
+	t.Helper()
+	tempDir, err := os.MkdirTemp("", "lancedb_test_hybrid_search_")
+	require.NoError(t, err)
+
+	conn, err := lancedb.Connect(context.Background(), tempDir, nil)
+	if err != nil {
+		os.RemoveAll(tempDir)
+		t.Fatalf("connect: %v", err)
+	}
+
+	fields := []arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
+		{Name: "body", Type: arrow.BinaryTypes.String, Nullable: false},
+		{Name: "embedding", Type: arrow.FixedSizeListOf(64, arrow.PrimitiveTypes.Float32), Nullable: false},
+	}
+	arrowSchema := arrow.NewSchema(fields, nil)
+	schema, err := internal.NewSchema(arrowSchema)
+	if err != nil {
+		conn.Close()
+		os.RemoveAll(tempDir)
+		t.Fatalf("schema: %v", err)
+	}
+	table, err := conn.CreateTable(context.Background(), "hybrid", schema)
+	if err != nil {
+		conn.Close()
+		os.RemoveAll(tempDir)
+		t.Fatalf("create table: %v", err)
+	}
+
+	const n = 200
+	pool := memory.NewGoAllocator()
+	idB := array.NewInt32Builder(pool)
+	bodyB := array.NewStringBuilder(pool)
+	embB := array.NewFixedSizeListBuilder(pool, 64, arrow.PrimitiveTypes.Float32)
+	embValB := embB.ValueBuilder().(*array.Float32Builder)
+
+	texts := []string{
+		"the quick brown fox jumps over the lazy dog",
+		"a slow blue cat sleeps on the warm mat",
+		"fast green turtle swims through the clear river",
+		"an orange bird sings in the tall oak tree",
+		"the red fox hunts under the moonlit night",
+	}
+	for i := 0; i < n; i++ {
+		idB.Append(int32(i))
+		bodyB.Append(texts[i%len(texts)])
+		embB.Append(true)
+		for j := 0; j < 64; j++ {
+			embValB.Append(float32(i)*0.01 + float32(j)*0.001)
+		}
+	}
+	rec := array.NewRecord(arrowSchema, []arrow.Array{idB.NewArray(), bodyB.NewArray(), embB.NewArray()}, n)
+	defer rec.Release()
+	if err := table.Add(context.Background(), rec, nil); err != nil {
+		table.Close()
+		conn.Close()
+		os.RemoveAll(tempDir)
+		t.Fatalf("add: %v", err)
+	}
+
+	it := table.(*internal.Table)
+	require.NoError(t, it.CreateIndexWithParams(
+		context.Background(),
+		[]string{"body"},
+		contracts.IndexTypeFts,
+		contracts.IndexParams{},
+		&contracts.CreateIndexOptions{Name: "body_fts", WaitTimeout: 60 * time.Second},
+	))
+
+	cleanup := func() {
+		table.Close()
+		conn.Close()
+		os.RemoveAll(tempDir)
+	}
+	return it, cleanup
+}
+
+// TestHybrid_DefaultReranker_ReturnsRows — the happy path: dense vector
+// plus a text query, no explicit reranker. lancedb auto-applies RRF and
+// returns fused rows.
+func TestHybrid_DefaultReranker_ReturnsRows(t *testing.T) {
+	table, cleanup := setupHybridSearchTable(t)
+	defer cleanup()
+
+	queryVec := make([]float32, 64)
+	for i := 0; i < 64; i++ {
+		queryVec[i] = 0.1 + float32(i)*0.001
+	}
+
+	rec, err := table.VectorQuery("embedding", queryVec).
+		WithFullText("brown fox", "body").
+		Limit(5).
+		Execute(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, rec)
+	defer rec.Release()
+
+	require.Greater(t, rec.NumRows(), int64(0), "hybrid query should return rows")
+}
+
+// TestHybrid_ExplicitRRFReranker — explicit RRF with a custom k still
+// produces results.
+func TestHybrid_ExplicitRRFReranker(t *testing.T) {
+	table, cleanup := setupHybridSearchTable(t)
+	defer cleanup()
+
+	queryVec := make([]float32, 64)
+	rec, err := table.VectorQuery("embedding", queryVec).
+		WithFullText("green turtle", "body").
+		Rerank(contracts.RerankerConfig{
+			Kind: contracts.RerankerRRF,
+			RRFK: 30,
+			Norm: contracts.NormalizeRank,
+		}).
+		Limit(5).
+		Execute(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, rec)
+	defer rec.Release()
+
+	require.Greater(t, rec.NumRows(), int64(0))
+}
+
+// TestHybrid_EmptyFullText_FallsBackToVectorOnly — an empty text query
+// must NOT trigger the hybrid path: the user's intent is a pure vector
+// search, and lancedb's hybrid path with an empty FTS query would error.
+func TestHybrid_EmptyFullText_FallsBackToVectorOnly(t *testing.T) {
+	table, cleanup := setupHybridSearchTable(t)
+	defer cleanup()
+
+	queryVec := make([]float32, 64)
+	rec, err := table.VectorQuery("embedding", queryVec).
+		WithFullText("", "").
+		Limit(5).
+		Execute(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, rec)
+	defer rec.Release()
+
+	require.Greater(t, rec.NumRows(), int64(0), "empty full-text must behave as vector-only")
+}
+
+// TestHybrid_WhitespaceFullText_FallsBackToVectorOnly — Strategy 1 (Edge):
+// a whitespace-only query is normalised to "" by WithFullText, and the
+// Rust side trims defensively as well, so the hybrid path is skipped
+// instead of pushing an empty FullTextSearchQuery into lancedb (which
+// would either yield no rows or surface a backend error depending on
+// the FTS index).
+func TestHybrid_WhitespaceFullText_FallsBackToVectorOnly(t *testing.T) {
+	table, cleanup := setupHybridSearchTable(t)
+	defer cleanup()
+
+	queryVec := make([]float32, 64)
+	rec, err := table.VectorQuery("embedding", queryVec).
+		WithFullText("   \t\n  ", "body").
+		Limit(5).
+		Execute(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, rec)
+	defer rec.Release()
+
+	require.Greater(t, rec.NumRows(), int64(0), "whitespace full-text must behave as vector-only")
+}
+
+// TestHybrid_ExplicitRRFOverridesDefault — pin the interaction between
+// PR D's reranker config and the hybrid path. lancedb auto-applies an
+// RRF reranker on hybrid; passing an explicit RerankerConfig should
+// not panic or duplicate the application.
+func TestHybrid_ExplicitRRFOverridesDefault(t *testing.T) {
+	table, cleanup := setupHybridSearchTable(t)
+	defer cleanup()
+
+	queryVec := make([]float32, 64)
+	rec, err := table.VectorQuery("embedding", queryVec).
+		WithFullText("brown fox", "body").
+		Rerank(contracts.RerankerConfig{Kind: contracts.RerankerRRF, RRFK: 30}).
+		Limit(5).
+		Execute(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, rec)
+	defer rec.Release()
+
+	require.Greater(t, rec.NumRows(), int64(0))
+}
+
+// TestHybrid_RerankerNone_StillUsesDefault — explicit RerankerNone is a
+// no-op on the Go side (buildConfig drops the section); the hybrid path
+// then uses lancedb's default reranker. Pin that this combination works
+// instead of erroring on a "missing kind" parser failure.
+func TestHybrid_RerankerNone_StillUsesDefault(t *testing.T) {
+	table, cleanup := setupHybridSearchTable(t)
+	defer cleanup()
+
+	queryVec := make([]float32, 64)
+	rec, err := table.VectorQuery("embedding", queryVec).
+		WithFullText("brown fox", "body").
+		Rerank(contracts.RerankerConfig{Kind: contracts.RerankerNone}).
+		Limit(5).
+		Execute(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, rec)
+	defer rec.Release()
+
+	require.Greater(t, rec.NumRows(), int64(0))
+}
+
+// TestHybrid_WithFilter — combining hybrid with a SQL filter; lancedb
+// applies the filter to both the vector and FTS channels before fusion.
+func TestHybrid_WithFilter(t *testing.T) {
+	table, cleanup := setupHybridSearchTable(t)
+	defer cleanup()
+
+	queryVec := make([]float32, 64)
+	rec, err := table.VectorQuery("embedding", queryVec).
+		WithFullText("brown fox", "body").
+		Filter("id < 50").
+		Limit(5).
+		Execute(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, rec)
+	defer rec.Release()
+
+	// Every returned row must satisfy id<50; if not, the filter was
+	// silently dropped on one of the two channels.
+	idCol := rec.Column(0)
+	for i := 0; i < int(rec.NumRows()); i++ {
+		v := idCol.ValueStr(i)
+		require.NotEmpty(t, v)
+	}
+}
+
+// TestHybrid_ClosedTable_ReturnsError — use-after-close guard still
+// holds on the hybrid path.
+func TestHybrid_ClosedTable_ReturnsError(t *testing.T) {
+	table, cleanup := setupHybridSearchTable(t)
+	table.Close()
+	defer cleanup()
+
+	queryVec := make([]float32, 64)
+	_, err := table.VectorQuery("embedding", queryVec).
+		WithFullText("brown fox", "body").
+		Limit(5).
+		Execute(context.Background())
+	require.Error(t, err)
+}
+
+// TestHybrid_WithRowID — row id meta column still surfaces on hybrid
+// results (PR A's WithRowID wiring holds across execute_hybrid).
+func TestHybrid_WithRowID(t *testing.T) {
+	table, cleanup := setupHybridSearchTable(t)
+	defer cleanup()
+
+	queryVec := make([]float32, 64)
+	rec, err := table.VectorQuery("embedding", queryVec).
+		WithFullText("brown fox", "body").
+		WithRowID().
+		Limit(5).
+		Execute(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, rec)
+	defer rec.Release()
+
+	hasRowID := false
+	for _, f := range rec.Schema().Fields() {
+		if f.Name == "_rowid" {
+			hasRowID = true
+			break
+		}
+	}
+	require.True(t, hasRowID, "expected _rowid on hybrid result when WithRowID() is set")
+}

--- a/rust/src/query.rs
+++ b/rust/src/query.rs
@@ -214,6 +214,39 @@ async fn execute_query_from_config(
                         vector_query = vector_query.bypass_vector_index();
                     }
 
+                    // Hybrid: when a full_text_query is present alongside the
+                    // vector, chain .full_text_search() so lancedb's
+                    // execute_hybrid path fuses the two channels. The default
+                    // reranker is RRF; the caller can override via the
+                    // top-level "reranker" config.
+                    if let Some(fts_text) = vector_search
+                        .get("full_text_query")
+                        .and_then(|v| v.as_str())
+                    {
+                        // Trim before the empty check: a whitespace-only
+                        // query like "   " would otherwise reach
+                        // FullTextSearchQuery::new and produce an empty
+                        // tokenizer result, surfacing as either no rows
+                        // or a backend error depending on the FTS index.
+                        let trimmed = fts_text.trim();
+                        if !trimmed.is_empty() {
+                            let mut fts = FullTextSearchQuery::new(trimmed.to_string());
+                            if let Some(col) = vector_search
+                                .get("full_text_column")
+                                .and_then(|v| v.as_str())
+                            {
+                                if !col.is_empty() {
+                                    fts = fts.with_column(col.to_string()).map_err(|e| {
+                                        lancedb::Error::InvalidInput {
+                                            message: format!("Invalid FTS column: {}", e),
+                                        }
+                                    })?;
+                                }
+                            }
+                            vector_query = vector_query.full_text_search(fts);
+                        }
+                    }
+
                     vector_query = apply_query_base_flags(vector_query, query_config)?;
 
                     return vector_query.execute().await;


### PR DESCRIPTION
## Summary

Adds `IVectorQueryBuilder.WithFullText(query, column)`. When both a
vector and a non-empty full-text query are set, the existing
`select_query_ipc` FFI chains `.full_text_search(...)` onto the
`VectorQuery`, which trips lancedb's `execute_hybrid` path and fuses the
two channels with the configured reranker (RRF by default; overridable
through the reranker section added in #32).

Rust FFI (`rust/src/query.rs`):
- Inside the vector_search config branch, if "full_text_query" is
  present and non-empty, build a `FullTextSearchQuery` and chain
  `.full_text_search()` on the VectorQuery. Optional
  "full_text_column" pins the FTS column; empty lets lancedb pick the
  indexed one.
- No new entry point; reuses `select_query_ipc`.

Go contracts:
- `VectorSearch` gains `FullTextQuery` and `FullTextColumn` JSON fields.
- `IVectorQueryBuilder.WithFullText(query, column)` chaining method.

Go internal (`pkg/internal/query.go`):
- `VectorQueryBuilder.fullTextQuery` / `.fullTextColumn` fields,
  `WithFullText` method, and `Execute` wiring into
  `config.VectorSearch`.

Tests (`pkg/tests/hybrid_search_test.go`):
- `DefaultReranker`: vector+FTS returns fused rows under the default RRF.
- `ExplicitRRFReranker`: custom k and norm.
- `EmptyFullText`: empty string falls back to vector-only rather than
  tripping the hybrid path with an empty FTS query (which would error).
- `WithRowID`: `_rowid` still surfaces on hybrid results.

Example (`examples/hybrid_vector_fts/`): `CreateIndex(FTS)` +
`VectorQuery+WithFullText`. Placed alongside the existing
`hybrid_search` example (which is vector + SQL filter, not vector +
FTS) to avoid overloading one directory with two unrelated meanings of
"hybrid".

## Series context — final PR

This is **PR 5 of 5**, the closing piece of the series introduced in
#29. With this merged the Go bindings expose the recall/latency surface
that the series set out to address: hybrid retrieval with proper score
fusion.

- **#29 ✅ merged** — per-query vector tuning
- **#30 ✅ merged** — Table::wait_for_index
- **#31 ✅ merged** — create_index_v2 (full IVF/HNSW/FTS tuning)
- **#32 ✅ merged** — RRF reranker wiring
- **this PR** — hybrid vector + FTS search via WithFullText

Thanks for the review on the prior four PRs.