### PR TITLE
feat: expose OptimizeAction sub-actions (Compact / Prune / Index)

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -148,6 +148,12 @@ merge-insert: check-libraries
 	@cd merge_insert && \
 	CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" go run merge_insert.go
 
+optimize-action: check-libraries
+	@echo "🚀 Running OptimizeWithAction example..."
+	@echo "Platform: $(PLATFORM_ARCH)"
+	@cd optimize_action && \
+	CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" go run optimize_action.go
+
 query-tuning: check-libraries
 	@echo "🚀 Running Per-Query Tuning example..."
 	@echo "Platform: $(PLATFORM_ARCH)"

--- a/examples/optimize_action/optimize_action.go
+++ b/examples/optimize_action/optimize_action.go
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The LanceDB Authors
+
+// OptimizeWithAction example.
+//
+// Demonstrates the configurable optimize sub-actions:
+//   - OptimizeCompact: merge small fragments
+//   - OptimizePrune:   reclaim disk taken by old versions
+//   - OptimizeIndex:   fold unindexed rows into existing indices
+//   - OptimizeAll:     run everything (default)
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/array"
+	"github.com/apache/arrow/go/v17/arrow/memory"
+
+	"github.com/lancedb/lancedb-go/pkg/contracts"
+	"github.com/lancedb/lancedb-go/pkg/lancedb"
+)
+
+func u64(v uint64) *uint64 { return &v }
+func bp(v bool) *bool      { return &v }
+
+func main() {
+	fmt.Println("🚀 LanceDB Go SDK - OptimizeWithAction Example")
+	fmt.Println("===============================================")
+
+	ctx := context.Background()
+	tempDir, err := os.MkdirTemp("", "lancedb_optimize_action_example_")
+	if err != nil {
+		log.Fatalf("temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	conn, err := lancedb.Connect(ctx, tempDir, nil)
+	if err != nil {
+		log.Fatalf("connect: %v", err)
+	}
+	defer conn.Close()
+
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
+		{Name: "name", Type: arrow.BinaryTypes.String, Nullable: false},
+	}, nil)
+	schema, err := lancedb.NewSchema(arrowSchema)
+	if err != nil {
+		log.Fatalf("schema: %v", err)
+	}
+	table, err := conn.CreateTable(ctx, "docs", schema)
+	if err != nil {
+		log.Fatalf("create table: %v", err)
+	}
+	defer table.Close()
+
+	// Three small Add calls => three fragments worth compacting.
+	pool := memory.NewGoAllocator()
+	for batch := 0; batch < 3; batch++ {
+		idB := array.NewInt32Builder(pool)
+		nB := array.NewStringBuilder(pool)
+		for i := 0; i < 10; i++ {
+			idB.Append(int32(batch*10 + i))
+			nB.Append(fmt.Sprintf("row-%d", batch*10+i))
+		}
+		rec := array.NewRecord(arrowSchema,
+			[]arrow.Array{idB.NewArray(), nB.NewArray()}, 10)
+		if err := table.Add(ctx, rec, nil); err != nil {
+			rec.Release()
+			log.Fatalf("add: %v", err)
+		}
+		rec.Release()
+	}
+
+	fmt.Println("\n▶ Compact (TargetRowsPerFragment=100)")
+	stats, err := table.OptimizeWithAction(ctx, contracts.OptimizeAction{
+		Kind: contracts.OptimizeCompact,
+		Compaction: contracts.CompactionParams{
+			TargetRowsPerFragment: u64(100),
+		},
+	})
+	if err != nil {
+		log.Fatalf("compact: %v", err)
+	}
+	if stats.Compaction != nil {
+		fmt.Printf("  fragments_removed=%v, fragments_added=%v, files_removed=%v, files_added=%v\n",
+			ptrOrZero(stats.Compaction.FragmentsRemoved),
+			ptrOrZero(stats.Compaction.FragmentsAdded),
+			ptrOrZero(stats.Compaction.FilesRemoved),
+			ptrOrZero(stats.Compaction.FilesAdded),
+		)
+	}
+
+	fmt.Println("\n▶ Prune (OlderThan=1h, DeleteUnverified=true)")
+	if _, err := table.OptimizeWithAction(ctx, contracts.OptimizeAction{
+		Kind: contracts.OptimizePrune,
+		Prune: contracts.PruneParams{
+			OlderThan:        time.Hour,
+			DeleteUnverified: bp(true),
+		},
+	}); err != nil {
+		log.Fatalf("prune: %v", err)
+	}
+	fmt.Println("  ✓ prune ok")
+
+	fmt.Println("\n▶ Index (no-op when no index exists)")
+	if _, err := table.OptimizeWithAction(ctx, contracts.OptimizeAction{
+		Kind: contracts.OptimizeIndex,
+	}); err != nil {
+		log.Fatalf("index: %v", err)
+	}
+	fmt.Println("  ✓ index ok")
+
+	fmt.Println("\n▶ All (legacy Optimize entry point)")
+	if _, err := table.Optimize(ctx); err != nil {
+		log.Fatalf("all: %v", err)
+	}
+	fmt.Println("  ✓ all ok")
+
+	fmt.Println("\n✅ OptimizeWithAction example complete")
+}
+
+func ptrOrZero(p *int64) int64 {
+	if p == nil {
+		return 0
+	}
+	return *p
+}

--- a/include/lancedb.h
+++ b/include/lancedb.h
@@ -260,6 +260,17 @@ struct SimpleResult *simple_lancedb_table_close(void *table_handle);
 struct SimpleResult *simple_lancedb_table_optimize(void *table_handle, char **optimize_stats_json);
 
 /**
+ * Optimize the on-disk data and indices with a configurable
+ * OptimizeAction. The `action_json` argument selects the sub-action and
+ * carries its options; `OptimizeAction::All` (the original behaviour
+ * available via `simple_lancedb_table_optimize`) corresponds to
+ * `{"type":"all"}`.
+ */
+struct SimpleResult *simple_lancedb_table_optimize_v2(void *table_handle,
+                                                      const char *action_json,
+                                                      char **optimize_stats_json);
+
+/**
  * Free a VersionInfo structure
  */
 void lancedb_version_info_free(struct VersionInfo *version);

--- a/pkg/contracts/i_table.go
+++ b/pkg/contracts/i_table.go
@@ -107,8 +107,15 @@ type ITable interface {
 	// SelectWithLimit returns a limited number of records with optional offset
 	SelectWithLimit(ctx context.Context, limit int, offset int) ([]map[string]interface{}, error)
 
-	// Optimize the on-disk data and indices for better performance
+	// Optimize the on-disk data and indices for better performance.
+	// Equivalent to OptimizeWithAction(ctx, OptimizeAction{Kind: OptimizeAll}).
 	Optimize(ctx context.Context) (*OptimizeStats, error)
+
+	// OptimizeWithAction runs a configurable optimize action — Compact,
+	// Prune, Index, or All. Use this when you need to control which
+	// sub-pass runs (e.g. only Prune to reclaim disk after deletions)
+	// or to tune per-action parameters.
+	OptimizeWithAction(ctx context.Context, action OptimizeAction) (*OptimizeStats, error)
 }
 
 // AddDataOptions configures how data is added to a Table

--- a/pkg/contracts/types.go
+++ b/pkg/contracts/types.go
@@ -234,6 +234,61 @@ type RemovalStats struct {
 	OldVersions  *int64 `json:"old_versions,omitempty"`
 }
 
+// OptimizeActionKind picks which sub-action OptimizeWithAction performs.
+// Mirrors lancedb::table::OptimizeAction.
+type OptimizeActionKind int
+
+const (
+	// OptimizeAll runs every optimization with default values (the same
+	// as the existing Optimize(ctx) entry point).
+	OptimizeAll OptimizeActionKind = iota
+	// OptimizeCompact merges small fragments into larger ones. Useful
+	// after a burst of writes; not needed for read-only tables.
+	OptimizeCompact
+	// OptimizePrune removes old dataset versions. Reclaims disk
+	// previously kept around for time travel.
+	OptimizePrune
+	// OptimizeIndex incrementally folds unindexed rows into existing
+	// indices. Faster than rebuilding the index from scratch.
+	OptimizeIndex
+)
+
+// CompactionParams carries CompactionOptions for OptimizeCompact. All
+// fields are optional — pointer fields treat nil as "backend default".
+type CompactionParams struct {
+	TargetRowsPerFragment         *uint64  `json:"target_rows_per_fragment,omitempty"`
+	MaxRowsPerGroup               *uint64  `json:"max_rows_per_group,omitempty"`
+	MaxBytesPerFile               *uint64  `json:"max_bytes_per_file,omitempty"`
+	MaterializeDeletions          *bool    `json:"materialize_deletions,omitempty"`
+	MaterializeDeletionsThreshold *float32 `json:"materialize_deletions_threshold,omitempty"`
+	NumThreads                    *uint64  `json:"num_threads,omitempty"`
+	BatchSize                     *uint64  `json:"batch_size,omitempty"`
+}
+
+// PruneParams carries the OptimizeAction::Prune options.
+type PruneParams struct {
+	// OlderThan is the minimum age a version must reach before it's
+	// eligible for pruning. Zero leaves the lancedb default.
+	OlderThan time.Duration
+	// DeleteUnverified pairs with OlderThan to override lancedb's
+	// 7-day safety margin for in-progress transactions. nil leaves the
+	// backend default.
+	DeleteUnverified *bool
+	// ErrorIfTaggedOldVersions makes prune fail when an old version is
+	// referenced by a dataset tag. nil leaves the backend default.
+	ErrorIfTaggedOldVersions *bool
+}
+
+// OptimizeAction picks the sub-action and (when relevant) carries its
+// parameters. Use one of the OptimizeAll/OptimizeCompact/OptimizePrune/
+// OptimizeIndex constants for Kind; the matching params field is read
+// only for that kind.
+type OptimizeAction struct {
+	Kind       OptimizeActionKind
+	Compaction CompactionParams
+	Prune      PruneParams
+}
+
 // OptimizeStats represents stats of the version pruning
 type OptimizeStats struct {
 	Compaction *CompactionMetrics `json:"compaction,omitempty"`

--- a/pkg/internal/table.go
+++ b/pkg/internal/table.go
@@ -767,8 +767,17 @@ func (t *Table) SelectWithLimit(ctx context.Context, limit int, offset int) ([]m
 	})
 }
 
-// Optimize the on-disk data and indices for better performance
-func (t *Table) Optimize(_ context.Context) (*contracts.OptimizeStats, error) {
+// Optimize the on-disk data and indices for better performance.
+// Equivalent to OptimizeWithAction(ctx, OptimizeAction{Kind: OptimizeAll}).
+func (t *Table) Optimize(ctx context.Context) (*contracts.OptimizeStats, error) {
+	return t.OptimizeWithAction(ctx, contracts.OptimizeAction{Kind: contracts.OptimizeAll})
+}
+
+// OptimizeWithAction runs the configured OptimizeAction (All / Compact /
+// Prune / Index) and returns the resulting stats.
+//
+//nolint:gocritic
+func (t *Table) OptimizeWithAction(_ context.Context, action contracts.OptimizeAction) (*contracts.OptimizeStats, error) {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 
@@ -776,8 +785,16 @@ func (t *Table) Optimize(_ context.Context) (*contracts.OptimizeStats, error) {
 		return nil, fmt.Errorf("table is closed")
 	}
 
+	actionJSON, err := optimizeActionToJSON(action)
+	if err != nil {
+		return nil, err
+	}
+	cActionJSON := C.CString(string(actionJSON))
+	// #nosec G103 - Required for freeing C allocated string memory
+	defer C.free(unsafe.Pointer(cActionJSON))
+
 	var optimizeStatsJSON *C.char
-	result := C.simple_lancedb_table_optimize(t.handle, &optimizeStatsJSON)
+	result := C.simple_lancedb_table_optimize_v2(t.handle, cActionJSON, &optimizeStatsJSON)
 	defer C.simple_lancedb_result_free(result)
 
 	if !result.SUCCESS {
@@ -795,13 +812,68 @@ func (t *Table) Optimize(_ context.Context) (*contracts.OptimizeStats, error) {
 	jsonStr := C.GoString(optimizeStatsJSON)
 	C.simple_lancedb_free_string(optimizeStatsJSON)
 
-	// Parse JSON response
 	var optimizeStats contracts.OptimizeStats
 	if err := json.Unmarshal([]byte(jsonStr), &optimizeStats); err != nil {
 		return nil, fmt.Errorf("failed to parse optimize stats JSON: %w", err)
 	}
-
 	return &optimizeStats, nil
+}
+
+// optimizeActionToJSON converts the public OptimizeAction into the wire
+// shape consumed by simple_lancedb_table_optimize_v2. Per-kind fields
+// from CompactionParams / PruneParams that are nil are omitted so the
+// Rust side falls back to its defaults.
+//
+// Exported only as a private helper; callers should use
+// OptimizeWithAction (or Optimize for the All shortcut).
+func optimizeActionToJSON(action contracts.OptimizeAction) ([]byte, error) {
+	switch action.Kind {
+	case contracts.OptimizeAll:
+		return json.Marshal(struct {
+			Type string `json:"type"`
+		}{Type: "all"})
+
+	case contracts.OptimizeCompact:
+		envelope := struct {
+			Type string `json:"type"`
+			contracts.CompactionParams
+		}{
+			Type:             "compact",
+			CompactionParams: action.Compaction,
+		}
+		return json.Marshal(envelope)
+
+	case contracts.OptimizePrune:
+		envelope := struct {
+			Type                     string  `json:"type"`
+			OlderThanSeconds         *uint64 `json:"older_than_seconds,omitempty"`
+			DeleteUnverified         *bool   `json:"delete_unverified,omitempty"`
+			ErrorIfTaggedOldVersions *bool   `json:"error_if_tagged_old_versions,omitempty"`
+		}{Type: "prune"}
+		if action.Prune.OlderThan > 0 {
+			// Floor sub-second positive durations to 1s instead of
+			// truncating to 0 — the Rust side maps 0 to
+			// TimeDelta::seconds(0) (immediate cutoff), which would
+			// silently prune very recent versions when callers pass a
+			// small duration like 500*time.Millisecond.
+			secs := uint64(action.Prune.OlderThan / time.Second)
+			if secs == 0 {
+				secs = 1
+			}
+			envelope.OlderThanSeconds = &secs
+		}
+		envelope.DeleteUnverified = action.Prune.DeleteUnverified
+		envelope.ErrorIfTaggedOldVersions = action.Prune.ErrorIfTaggedOldVersions
+		return json.Marshal(envelope)
+
+	case contracts.OptimizeIndex:
+		return json.Marshal(struct {
+			Type string `json:"type"`
+		}{Type: "index"})
+
+	default:
+		return nil, fmt.Errorf("unknown OptimizeActionKind: %d", action.Kind)
+	}
 }
 
 // indexTypeToString converts IndexType enum to string representation

--- a/pkg/tests/optimize_action_test.go
+++ b/pkg/tests/optimize_action_test.go
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The LanceDB Authors
+
+package tests
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/array"
+	"github.com/apache/arrow/go/v17/arrow/memory"
+	"github.com/stretchr/testify/require"
+
+	"github.com/lancedb/lancedb-go/pkg/contracts"
+	"github.com/lancedb/lancedb-go/pkg/internal"
+	"github.com/lancedb/lancedb-go/pkg/lancedb"
+)
+
+// setupOptimizeTable creates a table with a few small fragments so
+// Compact / Prune sub-actions have something to chew on.
+func setupOptimizeTable(t *testing.T) (*internal.Table, func()) {
+	t.Helper()
+	tempDir, err := os.MkdirTemp("", "lancedb_test_optimize_action_")
+	require.NoError(t, err)
+
+	conn, err := lancedb.Connect(context.Background(), tempDir, nil)
+	if err != nil {
+		os.RemoveAll(tempDir)
+		t.Fatalf("connect: %v", err)
+	}
+
+	fields := []arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
+		{Name: "name", Type: arrow.BinaryTypes.String, Nullable: false},
+	}
+	arrowSchema := arrow.NewSchema(fields, nil)
+	schema, err := internal.NewSchema(arrowSchema)
+	if err != nil {
+		conn.Close()
+		os.RemoveAll(tempDir)
+		t.Fatalf("schema: %v", err)
+	}
+	table, err := conn.CreateTable(context.Background(), "opt", schema)
+	if err != nil {
+		conn.Close()
+		os.RemoveAll(tempDir)
+		t.Fatalf("create: %v", err)
+	}
+
+	pool := memory.NewGoAllocator()
+	// Three small Add calls so multiple fragments exist.
+	for batch := 0; batch < 3; batch++ {
+		idB := array.NewInt32Builder(pool)
+		nB := array.NewStringBuilder(pool)
+		for i := 0; i < 10; i++ {
+			idB.Append(int32(batch*10 + i))
+			nB.Append("row")
+		}
+		rec := array.NewRecord(arrowSchema,
+			[]arrow.Array{idB.NewArray(), nB.NewArray()}, 10)
+		if err := table.Add(context.Background(), rec, nil); err != nil {
+			rec.Release()
+			table.Close()
+			conn.Close()
+			os.RemoveAll(tempDir)
+			t.Fatalf("add: %v", err)
+		}
+		rec.Release()
+	}
+
+	cleanup := func() {
+		table.Close()
+		conn.Close()
+		os.RemoveAll(tempDir)
+	}
+	return table.(*internal.Table), cleanup
+}
+
+// TestOptimize_AllShortcut — the legacy Optimize entry point still
+// works (and is internally identical to OptimizeWithAction(All)).
+func TestOptimize_AllShortcut(t *testing.T) {
+	table, cleanup := setupOptimizeTable(t)
+	defer cleanup()
+
+	stats, err := table.Optimize(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, stats)
+}
+
+// TestOptimizeWithAction_Compact — Compact runs and returns compaction
+// stats, including a non-nil FragmentsRemoved (we appended in 3 batches
+// so there's something to merge).
+func TestOptimizeWithAction_Compact(t *testing.T) {
+	table, cleanup := setupOptimizeTable(t)
+	defer cleanup()
+
+	stats, err := table.OptimizeWithAction(context.Background(), contracts.OptimizeAction{
+		Kind: contracts.OptimizeCompact,
+		Compaction: contracts.CompactionParams{
+			TargetRowsPerFragment: u64Ptr(100),
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, stats)
+	require.NotNil(t, stats.Compaction, "compact must populate Compaction")
+}
+
+// TestOptimizeWithAction_Prune — Prune does not error on a freshly
+// created table (no old versions to remove yet, but the call should
+// still succeed).
+func TestOptimizeWithAction_Prune(t *testing.T) {
+	table, cleanup := setupOptimizeTable(t)
+	defer cleanup()
+
+	deleteUnverified := true
+	stats, err := table.OptimizeWithAction(context.Background(), contracts.OptimizeAction{
+		Kind: contracts.OptimizePrune,
+		Prune: contracts.PruneParams{
+			OlderThan:        time.Hour,
+			DeleteUnverified: &deleteUnverified,
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, stats)
+}
+
+// TestOptimizeWithAction_Prune_SubSecondOlderThan — pin the sub-second
+// floor: 500ms used to truncate to 0 and reach the FFI as
+// older_than_seconds=0 (TimeDelta::seconds(0) = immediate cutoff),
+// silently pruning very recent versions. The fix floors any positive
+// sub-second duration to 1s.
+func TestOptimizeWithAction_Prune_SubSecondOlderThan(t *testing.T) {
+	table, cleanup := setupOptimizeTable(t)
+	defer cleanup()
+
+	stats, err := table.OptimizeWithAction(context.Background(), contracts.OptimizeAction{
+		Kind: contracts.OptimizePrune,
+		Prune: contracts.PruneParams{
+			OlderThan: 500 * time.Millisecond,
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, stats)
+}
+
+// TestOptimizeWithAction_Index — Index runs even when no index exists
+// on the table; lancedb should treat this as a no-op success.
+func TestOptimizeWithAction_Index(t *testing.T) {
+	table, cleanup := setupOptimizeTable(t)
+	defer cleanup()
+
+	stats, err := table.OptimizeWithAction(context.Background(), contracts.OptimizeAction{
+		Kind: contracts.OptimizeIndex,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, stats)
+}
+
+// TestOptimizeWithAction_UnknownKind_ReturnsError — guard against
+// out-of-range casts (e.g. contracts.OptimizeActionKind(99)) reaching
+// the FFI; the Go side must surface a normal error.
+func TestOptimizeWithAction_UnknownKind_ReturnsError(t *testing.T) {
+	table, cleanup := setupOptimizeTable(t)
+	defer cleanup()
+
+	_, err := table.OptimizeWithAction(context.Background(), contracts.OptimizeAction{
+		Kind: contracts.OptimizeActionKind(99),
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "OptimizeActionKind")
+}
+
+// TestOptimizeWithAction_ClosedTable — use-after-close guard.
+func TestOptimizeWithAction_ClosedTable(t *testing.T) {
+	table, cleanup := setupOptimizeTable(t)
+	table.Close()
+	defer cleanup()
+
+	_, err := table.OptimizeWithAction(context.Background(), contracts.OptimizeAction{
+		Kind: contracts.OptimizeAll,
+	})
+	require.Error(t, err)
+}
+
+func u64Ptr(v uint64) *uint64 { return &v }

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3990,6 +3990,7 @@ dependencies = [
  "arrow-ord",
  "arrow-schema",
  "cbindgen",
+ "chrono",
  "env_logger",
  "lancedb",
  "libc",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -31,6 +31,8 @@ arrow-cast = "56.2"
 arrow-ipc = "56.2"
 serde_json = "1.0"
 tokio-stream = "0.1"
+# Re-exported via lancedb::table::OptimizeAction::Prune.older_than.
+chrono = { version = "0.4", default-features = false, features = ["std"] }
 
 [target.aarch64-apple-darwin.dependencies]
 

--- a/rust/src/table.rs
+++ b/rust/src/table.rs
@@ -6,7 +6,8 @@
 use crate::ffi::{from_c_str, SimpleResult};
 use crate::runtime::get_simple_runtime;
 use crate::schema::create_arrow_schema_from_json;
-use lancedb::table::OptimizeAction;
+use chrono::TimeDelta;
+use lancedb::table::{CompactionOptions, OptimizeAction, OptimizeOptions};
 use std::ffi::CString;
 use std::os::raw::{c_char, c_void};
 use std::sync::Arc;
@@ -281,5 +282,254 @@ pub extern "C" fn simple_lancedb_table_optimize(
         Err(_) => Box::into_raw(Box::new(SimpleResult::error(
             "Panic in simple_lancedb_table_optimize".to_string(),
         ))),
+    }
+}
+
+/// Build a lancedb::table::OptimizeAction from the action JSON. Shape:
+///   {"type": "all"}                                  -> OptimizeAction::All
+///   {"type": "compact",
+///    "target_rows_per_fragment": <usize>?,
+///    "max_rows_per_group": <usize>?,
+///    "max_bytes_per_file": <usize>?,
+///    "materialize_deletions": <bool>?,
+///    "materialize_deletions_threshold": <f32>?,
+///    "num_threads": <usize>?,
+///    "batch_size": <usize>?}                          -> OptimizeAction::Compact
+///   {"type": "prune",
+///    "older_than_seconds": <u64>?,
+///    "delete_unverified": <bool>?,
+///    "error_if_tagged_old_versions": <bool>?}        -> OptimizeAction::Prune
+///   {"type": "index"}                                 -> OptimizeAction::Index
+///
+/// Unknown fields per branch are ignored. Returns Err(String) on a
+/// missing/unknown "type" or a value that doesn't fit the expected
+/// integer width.
+fn build_optimize_action(cfg: &serde_json::Value) -> Result<OptimizeAction, String> {
+    let kind = cfg
+        .get("type")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "OptimizeAction config requires a 'type' field".to_string())?;
+
+    let usize_opt = |k: &str| -> Result<Option<usize>, String> {
+        match cfg.get(k).and_then(|v| v.as_u64()) {
+            None => Ok(None),
+            Some(n) => usize::try_from(n)
+                .map(Some)
+                .map_err(|_| format!("'{}' value {} does not fit in usize", k, n)),
+        }
+    };
+    let bool_opt = |k: &str| -> Option<bool> { cfg.get(k).and_then(|v| v.as_bool()) };
+
+    match kind {
+        "all" => Ok(OptimizeAction::All),
+
+        "compact" => {
+            let mut options = CompactionOptions::default();
+            if let Some(n) = usize_opt("target_rows_per_fragment")? {
+                options.target_rows_per_fragment = n;
+            }
+            if let Some(n) = usize_opt("max_rows_per_group")? {
+                options.max_rows_per_group = n;
+            }
+            if let Some(n) = usize_opt("max_bytes_per_file")? {
+                options.max_bytes_per_file = Some(n);
+            }
+            if let Some(v) = bool_opt("materialize_deletions") {
+                options.materialize_deletions = v;
+            }
+            if let Some(f) = cfg
+                .get("materialize_deletions_threshold")
+                .and_then(|v| v.as_f64())
+            {
+                options.materialize_deletions_threshold = f as f32;
+            }
+            if let Some(n) = usize_opt("num_threads")? {
+                options.num_threads = Some(n);
+            }
+            if let Some(n) = usize_opt("batch_size")? {
+                options.batch_size = Some(n);
+            }
+            Ok(OptimizeAction::Compact {
+                options,
+                remap_options: None,
+            })
+        }
+
+        "prune" => {
+            let older_than = match cfg.get("older_than_seconds").and_then(|v| v.as_u64()) {
+                None => None,
+                Some(secs) => {
+                    // TimeDelta::try_seconds is fallible because the
+                    // chrono internal range is finite; wrap with a clear
+                    // error when the caller hands in something absurd.
+                    let i = i64::try_from(secs).map_err(|_| {
+                        format!("'older_than_seconds' value {} does not fit in i64", secs)
+                    })?;
+                    Some(TimeDelta::try_seconds(i).ok_or_else(|| {
+                        format!(
+                            "'older_than_seconds' value {} is out of TimeDelta range",
+                            secs
+                        )
+                    })?)
+                }
+            };
+            Ok(OptimizeAction::Prune {
+                older_than,
+                delete_unverified: bool_opt("delete_unverified"),
+                error_if_tagged_old_versions: bool_opt("error_if_tagged_old_versions"),
+            })
+        }
+
+        "index" => Ok(OptimizeAction::Index(OptimizeOptions::default())),
+
+        other => Err(format!("Unknown OptimizeAction type: {}", other)),
+    }
+}
+
+/// Optimize the on-disk data and indices with a configurable
+/// OptimizeAction. The `action_json` argument selects the sub-action and
+/// carries its options; `OptimizeAction::All` (the original behaviour
+/// available via `simple_lancedb_table_optimize`) corresponds to
+/// `{"type":"all"}`.
+#[no_mangle]
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+pub extern "C" fn simple_lancedb_table_optimize_v2(
+    table_handle: *mut c_void,
+    action_json: *const c_char,
+    optimize_stats_json: *mut *mut c_char,
+) -> *mut SimpleResult {
+    let result = std::panic::catch_unwind(|| -> SimpleResult {
+        if table_handle.is_null() || action_json.is_null() || optimize_stats_json.is_null() {
+            return SimpleResult::error("Invalid null arguments".to_string());
+        }
+
+        let cfg_str = match from_c_str(action_json) {
+            Ok(s) => s,
+            Err(e) => return SimpleResult::error(format!("Invalid action JSON: {}", e)),
+        };
+        let cfg: serde_json::Value = match serde_json::from_str(&cfg_str) {
+            Ok(v) => v,
+            Err(e) => return SimpleResult::error(format!("Failed to parse action JSON: {}", e)),
+        };
+        let action = match build_optimize_action(&cfg) {
+            Ok(a) => a,
+            Err(e) => return SimpleResult::error(e),
+        };
+
+        let table = unsafe { &*(table_handle as *const lancedb::Table) };
+        let rt = get_simple_runtime();
+
+        match rt.block_on(async { table.optimize(action).await }) {
+            Ok(stats) => {
+                let mut stats_json = serde_json::json!({});
+                if let Some(c) = stats.compaction {
+                    stats_json["compaction"] = serde_json::json!({
+                        "fragments_removed": c.fragments_removed,
+                        "fragments_added": c.fragments_added,
+                        "files_removed": c.files_removed,
+                        "files_added": c.files_added,
+                    });
+                }
+                if let Some(p) = stats.prune {
+                    stats_json["prune"] = serde_json::json!({
+                        "bytes_removed": p.bytes_removed,
+                        "old_versions": p.old_versions,
+                    });
+                }
+                match serde_json::to_string(&stats_json) {
+                    Ok(s) => match CString::new(s) {
+                        Ok(c) => {
+                            unsafe {
+                                *optimize_stats_json = c.into_raw();
+                            }
+                            SimpleResult::ok()
+                        }
+                        Err(_) => {
+                            SimpleResult::error("Failed to convert JSON to C string".to_string())
+                        }
+                    },
+                    Err(e) => {
+                        SimpleResult::error(format!("Failed to serialize optimize stats: {}", e))
+                    }
+                }
+            }
+            Err(e) => SimpleResult::error(format!("optimize_v2 failed: {}", e)),
+        }
+    });
+
+    match result {
+        Ok(res) => Box::into_raw(Box::new(res)),
+        Err(_) => Box::into_raw(Box::new(SimpleResult::error(
+            "Panic in simple_lancedb_table_optimize_v2".to_string(),
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_optimize_action_all() {
+        let a = build_optimize_action(&serde_json::json!({"type": "all"})).unwrap();
+        assert!(matches!(a, OptimizeAction::All));
+    }
+
+    #[test]
+    fn build_optimize_action_prune_with_options() {
+        let a = build_optimize_action(&serde_json::json!({
+            "type": "prune",
+            "older_than_seconds": 86400,
+            "delete_unverified": true,
+            "error_if_tagged_old_versions": false,
+        }))
+        .unwrap();
+        match a {
+            OptimizeAction::Prune {
+                older_than,
+                delete_unverified,
+                error_if_tagged_old_versions,
+            } => {
+                assert_eq!(older_than, Some(TimeDelta::try_seconds(86400).unwrap()));
+                assert_eq!(delete_unverified, Some(true));
+                assert_eq!(error_if_tagged_old_versions, Some(false));
+            }
+            other => panic!("expected Prune, got {:?}", std::mem::discriminant(&other)),
+        }
+    }
+
+    #[test]
+    fn build_optimize_action_compact_with_options() {
+        let a = build_optimize_action(&serde_json::json!({
+            "type": "compact",
+            "target_rows_per_fragment": 200000,
+            "materialize_deletions": false,
+        }))
+        .unwrap();
+        match a {
+            OptimizeAction::Compact { options, .. } => {
+                assert_eq!(options.target_rows_per_fragment, 200000);
+                assert!(!options.materialize_deletions);
+            }
+            other => panic!("expected Compact, got {:?}", std::mem::discriminant(&other)),
+        }
+    }
+
+    // OptimizeAction does not implement Debug, so the error-path tests
+    // can't use expect_err; pattern-match on the Result directly.
+    #[test]
+    fn build_optimize_action_unknown_kind_errors() {
+        match build_optimize_action(&serde_json::json!({"type": "what"})) {
+            Err(e) => assert!(e.contains("Unknown"), "got: {}", e),
+            Ok(_) => panic!("unknown type must error"),
+        }
+    }
+
+    #[test]
+    fn build_optimize_action_missing_type_errors() {
+        match build_optimize_action(&serde_json::json!({})) {
+            Err(e) => assert!(e.contains("'type'"), "got: {}", e),
+            Ok(_) => panic!("missing type must error"),
+        }
     }
 }


### PR DESCRIPTION
## Summary

The existing `Table.Optimize` entry point hardcodes `OptimizeAction::All`
and hides the per-sub-action tunables. This PR keeps `Optimize` as a
shortcut and adds `OptimizeWithAction` so callers can choose:

- **Compact** — merge small fragments after a write burst, with control
  over target_rows_per_fragment / max_rows_per_group / etc.
- **Prune** — reclaim disk taken by old dataset versions, with an
  older_than cutoff and the delete_unverified / error_if_tagged_old_versions
  knobs.
- **Index** — fold unindexed rows into existing indices without a full
  retrain (useful for IVF tables with frequent appends).
- **All** — the original behaviour, available via either entry point.

No new Cargo features. `chrono` was added as a direct dep because
`OptimizeAction::Prune.older_than` is `chrono::TimeDelta`.

Rust FFI (`rust/src/table.rs`):
- New `simple_lancedb_table_optimize_v2(handle, action_json, stats_json)`.
- `build_optimize_action` parses the JSON action, range-checks integer
  fields (rejects values that would silently truncate), and surfaces
  `Unknown OptimizeAction type` / `'<key>' value … does not fit`
  errors as normal SimpleResult failures.

Go contracts:
- `OptimizeActionKind` (All / Compact / Prune / Index).
- `CompactionParams` and `PruneParams` with pointer fields so unset ==
  backend default.
- `OptimizeAction { Kind, Compaction, Prune }`.
- `ITable.OptimizeWithAction(ctx, action)`. Existing `Optimize(ctx)`
  is preserved and now delegates to `{Kind: OptimizeAll}`.

Go internal (`pkg/internal/table.go`):
- `optimizeActionToJSON` builds the wire payload via an embedded-struct
  envelope (same single-Marshal trick used by CreateIndexWithParams).
  Unknown `OptimizeActionKind` casts return a normal error instead of
  reaching the FFI.

Tests:
- Go: All shortcut, Compact + TargetRowsPerFragment, Prune + OlderThan
  + DeleteUnverified, Index no-op, unknown-kind error, closed-table
  guard.
- Rust unit tests: action_all, compact_with_options, prune_with_options,
  unknown_kind_errors, missing_type_errors.

Example (`examples/optimize_action/`): seeds three Add batches into a
single table so Compact has fragments to merge, then runs each sub-action.

C header regenerated by cbindgen.

## Out of scope

- `OptimizeAction::Compact` accepts a `remap_options: Option<Arc<dyn IndexRemapperOptions>>`
  in lancedb that's not exposed; passing through a Go callable would
  require holding Arc<dyn …> across the FFI which is non-trivial. Left
  hardcoded to `None` until there's demand.