### PR TITLE
feat: expose Table::drop_index through the FFI

### DIFF
--- a/include/lancedb.h
+++ b/include/lancedb.h
@@ -147,6 +147,15 @@ struct SimpleResult *simple_lancedb_table_index_stats(void *table_handle,
                                                       char **index_stats_json);
 
 /**
+ * Drop the named index from the table. Returns SimpleResult::ok() when
+ * the backend reports success, or SimpleResult::error() with a
+ * backend-supplied message on a missing index / I/O failure / cancelled
+ * runtime. The Go layer is responsible for swallowing the not-found
+ * error when the caller asked for IF EXISTS semantics.
+ */
+struct SimpleResult *simple_lancedb_table_drop_index(void *table_handle, const char *index_name);
+
+/**
  * Wait for the named indices to finish building, with a timeout in
  * milliseconds. An empty `index_names` array defaults to all indices on
  * the table. A `timeout_ms` value of 0 means "wait essentially forever"

--- a/pkg/contracts/i_table.go
+++ b/pkg/contracts/i_table.go
@@ -69,6 +69,11 @@ type ITable interface {
 	// CreateIndexOptions (no name override, replace=false, no wait).
 	CreateIndexWithParams(ctx context.Context, columns []string, indexType IndexType, params IndexParams, opts *CreateIndexOptions) error
 
+	// DropIndex removes the named index from the table. Returns an error
+	// if the index does not exist or the backend operation fails — IF
+	// EXISTS semantics are the caller's responsibility.
+	DropIndex(ctx context.Context, name string) error
+
 	// GetAllIndexes returns information about all indexes present on the table
 	GetAllIndexes(ctx context.Context) ([]IndexInfo, error)
 

--- a/pkg/internal/table.go
+++ b/pkg/internal/table.go
@@ -351,6 +351,38 @@ func (t *Table) Delete(_ context.Context, filter string) error {
 	return nil
 }
 
+// DropIndex removes the named index from the table. Caller-side IF EXISTS
+// semantics are not implemented here — propagate the not-found error and
+// let the caller decide whether to swallow it.
+func (t *Table) DropIndex(_ context.Context, name string) error {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	if t.closed || t.handle == nil {
+		return fmt.Errorf("table is closed")
+	}
+
+	if name == "" {
+		return fmt.Errorf("index name cannot be empty")
+	}
+
+	cName := C.CString(name)
+	// #nosec G103 - Required for freeing C allocated string memory
+	defer C.free(unsafe.Pointer(cName))
+
+	result := C.simple_lancedb_table_drop_index(t.handle, cName)
+	defer C.simple_lancedb_result_free(result)
+
+	if !result.SUCCESS {
+		if result.ERROR_MESSAGE != nil {
+			errorMsg := C.GoString(result.ERROR_MESSAGE)
+			return fmt.Errorf("failed to drop index: %s", errorMsg)
+		}
+		return fmt.Errorf("failed to drop index: unknown error")
+	}
+	return nil
+}
+
 // CreateIndex creates an index on the specified columns
 func (t *Table) CreateIndex(ctx context.Context, columns []string, indexType contracts.IndexType) error {
 	return t.CreateIndexWithName(ctx, columns, indexType, "")

--- a/rust/src/index.rs
+++ b/rust/src/index.rs
@@ -298,6 +298,43 @@ pub extern "C" fn simple_lancedb_table_index_stats(
     }
 }
 
+/// Drop the named index from the table. Returns SimpleResult::ok() when
+/// the backend reports success, or SimpleResult::error() with a
+/// backend-supplied message on a missing index / I/O failure / cancelled
+/// runtime. The Go layer is responsible for swallowing the not-found
+/// error when the caller asked for IF EXISTS semantics.
+#[no_mangle]
+pub extern "C" fn simple_lancedb_table_drop_index(
+    table_handle: *mut c_void,
+    index_name: *const c_char,
+) -> *mut SimpleResult {
+    let result = std::panic::catch_unwind(|| -> SimpleResult {
+        if table_handle.is_null() || index_name.is_null() {
+            return SimpleResult::error("Invalid null arguments".to_string());
+        }
+
+        let index_name_str = match from_c_str(index_name) {
+            Ok(s) => s,
+            Err(e) => return SimpleResult::error(format!("Invalid index name: {}", e)),
+        };
+
+        let table = unsafe { &*(table_handle as *const lancedb::Table) };
+        let rt = get_simple_runtime();
+
+        match rt.block_on(async { table.drop_index(&index_name_str).await }) {
+            Ok(()) => SimpleResult::ok(),
+            Err(e) => SimpleResult::error(format!("drop_index failed: {}", e)),
+        }
+    });
+
+    match result {
+        Ok(res) => Box::into_raw(Box::new(res)),
+        Err(_) => Box::into_raw(Box::new(SimpleResult::error(
+            "Panic in simple_lancedb_table_drop_index".to_string(),
+        ))),
+    }
+}
+
 /// Wait for the named indices to finish building, with a timeout in
 /// milliseconds. An empty `index_names` array defaults to all indices on
 /// the table. A `timeout_ms` value of 0 means "wait essentially forever"


### PR DESCRIPTION
## Summary

Adds a thin pass-through binding for lancedb's existing
`Table::drop_index`. The Rust API has been stable, but no Go entry
point exists today — callers are stuck with `replace=true` on
`CreateIndex` as the only way to "remove" an index, which still
leaves the dataset metadata behind.

Mirrors the `simple_lancedb_table_index_stats` pattern: single C
string argument, panic-catch, owned `SimpleResult`.

## Changes

**Rust FFI (`rust/src/index.rs`):**
- New `simple_lancedb_table_drop_index(handle, name)` calling
  `table.drop_index(name).await` under the shared simple runtime.
- Caller-side IF EXISTS semantics not implemented — the not-found
  error is propagated so the Go layer can choose whether to swallow it.

**Go contracts (`pkg/contracts/i_table.go`):**
- `ITable.DropIndex(ctx, name) error`.

**Go internal (`pkg/internal/table.go`):**
- `Table.DropIndex` mirroring `Delete`: handle/closed checks,
  empty-name guard, `CString` lifecycle, error-message extraction.

**Generated header (`include/lancedb.h`):**
- `cbindgen` output regenerated by `scripts/build-native.sh`.
