### PR TITLE
feat: expose Table::update with raw SQL expressions through the FFI

### DIFF
--- a/include/lancedb.h
+++ b/include/lancedb.h
@@ -62,6 +62,37 @@ struct SimpleResult *simple_lancedb_table_update(void *table_handle,
                                                  const char *updates_json);
 
 /**
+ * Update rows using raw SQL expressions per column, with an optional
+ * predicate. Unlike `simple_lancedb_table_update`, the per-column values
+ * are passed through to lancedb's `UpdateBuilder.column(name, expr)`
+ * verbatim — the caller is responsible for quoting string literals
+ * (`'foo'`) and formatting vector literals (`[1.0, 2.0, ...]`). This
+ * matches the Rust `Table::update()` builder's semantics one-for-one and
+ * unlocks SQL expressions like `counter + 1` or `upper(name)` that the
+ * JSON-literal path cannot represent.
+ *
+ * `predicate` may be NULL or empty to update every row (no WHERE).
+ *
+ * `assignments_json` schema:
+ * ```json
+ * [
+ *   {"column": "i",    "expr": "i + 1"},
+ *   {"column": "name", "expr": "'foo'"}
+ * ]
+ * ```
+ * An array (not a map) preserves caller order and avoids `serde_json`
+ * `Map` ordering surprises across versions.
+ *
+ * On success `result_json` is set to a CString containing
+ * `{"rows_updated": <u64>, "version": <u64>}` which the caller must free
+ * via `simple_lancedb_free_string`.
+ */
+struct SimpleResult *simple_lancedb_table_update_expr(void *table_handle,
+                                                      const char *predicate,
+                                                      const char *assignments_json,
+                                                      char **result_json);
+
+/**
  * Add JSON data to a table (simple version)
  * Converts JSON array of objects to Arrow RecordBatch and adds to table
  */

--- a/pkg/contracts/i_table.go
+++ b/pkg/contracts/i_table.go
@@ -49,6 +49,22 @@ type ITable interface {
 	// The updates parameter is a map where keys are column names and values are the new values
 	Update(ctx context.Context, filter string, updates map[string]interface{}) error
 
+	// UpdateExpr is a thin pass-through to lancedb's Table::update builder
+	// that exposes raw SQL expressions per column and an optional filter.
+	//
+	// Differences from Update:
+	//   - filter == "" updates every row (no WHERE).
+	//   - assignments[i].Expr is forwarded verbatim — the caller quotes
+	//     string literals (`'foo'`) and formats vector literals
+	//     (`[1.0, 2.0, ...]`). This unlocks expressions the Update path
+	//     auto-quotes away, e.g. `counter + 1`, `upper(name)`,
+	//     `coalesce(other, 0)`.
+	//   - Returns rows_updated and the new commit version.
+	//
+	// An empty assignments slice is rejected — UPDATE with no SET is
+	// semantically a no-op and almost always a caller bug.
+	UpdateExpr(ctx context.Context, filter string, assignments []UpdateAssignment) (*UpdateResult, error)
+
 	// Delete removes records from the table that match the given filter
 	Delete(ctx context.Context, filter string) error
 

--- a/pkg/contracts/i_table.go
+++ b/pkg/contracts/i_table.go
@@ -49,22 +49,6 @@ type ITable interface {
 	// The updates parameter is a map where keys are column names and values are the new values
 	Update(ctx context.Context, filter string, updates map[string]interface{}) error
 
-	// UpdateExpr is a thin pass-through to lancedb's Table::update builder
-	// that exposes raw SQL expressions per column and an optional filter.
-	//
-	// Differences from Update:
-	//   - filter == "" updates every row (no WHERE).
-	//   - assignments[i].Expr is forwarded verbatim — the caller quotes
-	//     string literals (`'foo'`) and formats vector literals
-	//     (`[1.0, 2.0, ...]`). This unlocks expressions the Update path
-	//     auto-quotes away, e.g. `counter + 1`, `upper(name)`,
-	//     `coalesce(other, 0)`.
-	//   - Returns rows_updated and the new commit version.
-	//
-	// An empty assignments slice is rejected — UPDATE with no SET is
-	// semantically a no-op and almost always a caller bug.
-	UpdateExpr(ctx context.Context, filter string, assignments []UpdateAssignment) (*UpdateResult, error)
-
 	// Delete removes records from the table that match the given filter
 	Delete(ctx context.Context, filter string) error
 
@@ -137,6 +121,39 @@ type ITable interface {
 	// sub-pass runs (e.g. only Prune to reclaim disk after deletions)
 	// or to tune per-action parameters.
 	OptimizeWithAction(ctx context.Context, action OptimizeAction) (*OptimizeStats, error)
+}
+
+// ITableUpdateExpr is an optional capability extension layered on top of
+// ITable. Backends that support lancedb's raw-SQL-expression update
+// builder implement it; backends that don't are unaffected.
+//
+// Kept out of ITable so adding the capability to a downstream backend
+// (or removing it later) is not a source-breaking change for existing
+// ITable mocks/stubs. Callers detect the capability with a type
+// assertion:
+//
+//	if u, ok := table.(contracts.ITableUpdateExpr); ok {
+//	    res, err := u.UpdateExpr(ctx, filter, assignments)
+//	}
+//
+// The shipped *internal.Table implements this interface.
+type ITableUpdateExpr interface {
+	// UpdateExpr is a thin pass-through to lancedb's Table::update
+	// builder that exposes raw SQL expressions per column and an
+	// optional filter.
+	//
+	// Differences from ITable.Update:
+	//   - filter == "" updates every row (no WHERE).
+	//   - assignments[i].Expr is forwarded verbatim — the caller quotes
+	//     string literals (`'foo'`) and formats vector literals
+	//     (`[1.0, 2.0, ...]`). This unlocks expressions the Update path
+	//     auto-quotes away, e.g. `counter + 1`, `upper(name)`,
+	//     `coalesce(other, 0)`.
+	//   - Returns rows_updated and the new commit version.
+	//
+	// An empty assignments slice is rejected — UPDATE with no SET is
+	// semantically a no-op and almost always a caller bug.
+	UpdateExpr(ctx context.Context, filter string, assignments []UpdateAssignment) (*UpdateResult, error)
 }
 
 // AddDataOptions configures how data is added to a Table

--- a/pkg/contracts/types.go
+++ b/pkg/contracts/types.go
@@ -313,3 +313,18 @@ type MergeResult struct {
 	NumDeletedRows  uint64 `json:"num_deleted_rows"`
 	NumAttempts     uint32 `json:"num_attempts"`
 }
+
+// UpdateAssignment is a single SET clause forwarded to lancedb's
+// UpdateBuilder.column(name, expr). Expr is a raw SQL expression — the
+// caller must quote string literals (`'foo'`) and format vector
+// literals (`[1.0, 2.0, ...]`).
+type UpdateAssignment struct {
+	Column string `json:"column"`
+	Expr   string `json:"expr"`
+}
+
+// UpdateResult mirrors lancedb::table::update::UpdateResult's serde form.
+type UpdateResult struct {
+	RowsUpdated uint64 `json:"rows_updated"`
+	Version     uint64 `json:"version"`
+}

--- a/pkg/internal/table.go
+++ b/pkg/internal/table.go
@@ -321,6 +321,73 @@ func (t *Table) Update(_ context.Context, filter string, updates map[string]inte
 	return nil
 }
 
+// UpdateExpr forwards each assignment.Expr to lancedb's UpdateBuilder
+// verbatim and returns the resulting rows_updated / version pair.
+//
+// Empty filter == "" updates every row (no WHERE).
+//
+// Empty assignments is rejected — a SET-less UPDATE is almost always a
+// caller bug, and lancedb's own UpdateBuilder.execute() already enforces
+// the same precondition.
+func (t *Table) UpdateExpr(_ context.Context, filter string, assignments []contracts.UpdateAssignment) (*contracts.UpdateResult, error) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	if t.closed || t.handle == nil {
+		return nil, fmt.Errorf("table is closed")
+	}
+
+	if len(assignments) == 0 {
+		return nil, fmt.Errorf("at least one assignment must be specified")
+	}
+	for i, a := range assignments {
+		if a.Column == "" {
+			return nil, fmt.Errorf("assignment #%d: column name cannot be empty", i)
+		}
+	}
+
+	assignmentsJSON, err := json.Marshal(assignments)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal assignments to JSON: %w", err)
+	}
+
+	// A null predicate ptr signals "update all rows" on the Rust side.
+	// CString("") would also work but allocates a 1-byte block for nothing.
+	var cFilter *C.char
+	if filter != "" {
+		cFilter = C.CString(filter)
+		// #nosec G103 - Required for freeing C allocated string memory
+		defer C.free(unsafe.Pointer(cFilter))
+	}
+
+	cAssignments := C.CString(string(assignmentsJSON))
+	// #nosec G103 - Required for freeing C allocated string memory
+	defer C.free(unsafe.Pointer(cAssignments))
+
+	var resultJSON *C.char
+	result := C.simple_lancedb_table_update_expr(t.handle, cFilter, cAssignments, &resultJSON)
+	defer C.simple_lancedb_result_free(result)
+
+	if !result.SUCCESS {
+		if result.ERROR_MESSAGE != nil {
+			return nil, fmt.Errorf("failed to update rows: %s", C.GoString(result.ERROR_MESSAGE))
+		}
+		return nil, fmt.Errorf("failed to update rows: unknown error")
+	}
+
+	if resultJSON == nil {
+		return &contracts.UpdateResult{}, nil
+	}
+	jsonStr := C.GoString(resultJSON)
+	C.simple_lancedb_free_string(resultJSON)
+
+	var ur contracts.UpdateResult
+	if err := json.Unmarshal([]byte(jsonStr), &ur); err != nil {
+		return nil, fmt.Errorf("update_expr: failed to parse result JSON: %w", err)
+	}
+	return &ur, nil
+}
+
 // Delete deletes records from the Table based on a filter
 func (t *Table) Delete(_ context.Context, filter string) error {
 	t.mu.RLock()

--- a/pkg/internal/table.go
+++ b/pkg/internal/table.go
@@ -40,6 +40,10 @@ type Table struct {
 // Compile-time check to ensure Table implements ITable interface
 var _ contracts.ITable = (*Table)(nil)
 
+// Compile-time check that Table also implements the optional
+// raw-SQL-expression update capability extension.
+var _ contracts.ITableUpdateExpr = (*Table)(nil)
+
 // Name returns the name of the Table
 func (t *Table) Name() string {
 	return t.name

--- a/pkg/tests/update_expr_test.go
+++ b/pkg/tests/update_expr_test.go
@@ -1,0 +1,275 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The LanceDB Authors
+
+package tests
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/memory"
+
+	"github.com/lancedb/lancedb-go/pkg/contracts"
+	"github.com/lancedb/lancedb-go/pkg/internal"
+	"github.com/lancedb/lancedb-go/pkg/lancedb"
+)
+
+// TestUpdateExpr exercises the raw-SQL-expression update path. Each
+// sub-test seeds the table with a fixed record set and verifies the
+// post-update state via Select queries.
+func TestUpdateExpr(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "lancedb_test_update_expr_")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	conn, err := lancedb.Connect(context.Background(), tempDir, nil)
+	if err != nil {
+		t.Fatalf("failed to connect: %v", err)
+	}
+	defer conn.Close()
+
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
+		{Name: "name", Type: arrow.BinaryTypes.String, Nullable: false},
+		{Name: "score", Type: arrow.PrimitiveTypes.Float64, Nullable: true},
+	}, nil)
+	schema, err := internal.NewSchema(arrowSchema)
+	if err != nil {
+		t.Fatalf("failed to create schema: %v", err)
+	}
+
+	pool := memory.NewGoAllocator()
+
+	seed := func(t *testing.T, name string) contracts.ITable {
+		t.Helper()
+		table, err := conn.CreateTable(context.Background(), name, schema)
+		if err != nil {
+			t.Fatalf("create table: %v", err)
+		}
+		t.Cleanup(func() { _ = table.Close() })
+
+		rec := buildRecord(t, pool, arrowSchema,
+			[]int32{1, 2, 3, 4, 5},
+			[]string{"Alice", "Bob", "Charlie", "Diana", "Eve"},
+			[]float64{10, 20, 30, 40, 50})
+		defer rec.Release()
+		if err := table.Add(context.Background(), rec, nil); err != nil {
+			t.Fatalf("seed add: %v", err)
+		}
+		return table
+	}
+
+	t.Run("FilterAndStringLiteral", func(t *testing.T) {
+		table := seed(t, "update_expr_filter_literal")
+		res, err := table.UpdateExpr(context.Background(), "id > 3",
+			[]contracts.UpdateAssignment{
+				{Column: "name", Expr: "'updated'"},
+			})
+		if err != nil {
+			t.Fatalf("UpdateExpr: %v", err)
+		}
+		if res == nil {
+			t.Fatal("UpdateExpr returned nil result")
+		}
+		if res.RowsUpdated != 2 {
+			t.Errorf("RowsUpdated = %d, want 2", res.RowsUpdated)
+		}
+		if res.Version == 0 {
+			t.Errorf("Version = 0, want a non-zero post-update version")
+		}
+
+		// Verify: ids 4,5 → name="updated"; ids 1,2,3 unchanged.
+		rows, err := table.SelectWithFilter(context.Background(), "id > 3")
+		if err != nil {
+			t.Fatalf("SelectWithFilter: %v", err)
+		}
+		if len(rows) != 2 {
+			t.Fatalf("post-update row count = %d, want 2", len(rows))
+		}
+		for _, row := range rows {
+			if got, _ := row["name"].(string); got != "updated" {
+				t.Errorf("row %v name = %q, want %q", row["id"], got, "updated")
+			}
+		}
+	})
+
+	t.Run("SQLExpressionReadsCurrentValue", func(t *testing.T) {
+		// `score = score + 100` — the expression cannot be encoded by the
+		// JSON-literal Update path (it would auto-quote to `'score + 100'`
+		// and DataFusion would reject the cast). UpdateExpr forwards the
+		// expression verbatim so the per-row score doubles-plus-100 lands.
+		table := seed(t, "update_expr_sql")
+		res, err := table.UpdateExpr(context.Background(), "id <= 3",
+			[]contracts.UpdateAssignment{
+				{Column: "score", Expr: "score + 100"},
+			})
+		if err != nil {
+			t.Fatalf("UpdateExpr: %v", err)
+		}
+		if res.RowsUpdated != 3 {
+			t.Errorf("RowsUpdated = %d, want 3", res.RowsUpdated)
+		}
+
+		rows, err := table.SelectWithFilter(context.Background(), "id <= 3")
+		if err != nil {
+			t.Fatalf("SelectWithFilter: %v", err)
+		}
+		if len(rows) != 3 {
+			t.Fatalf("row count = %d, want 3", len(rows))
+		}
+		want := map[int32]float64{1: 110, 2: 120, 3: 130}
+		for _, row := range rows {
+			// Numeric columns can come back as int32 / int64 / float64
+			// depending on the JSON decoder path — mirror merge_insert_test's
+			// shape-tolerant extraction.
+			var id int32
+			switch v := row["id"].(type) {
+			case int32:
+				id = v
+			case int64:
+				id = int32(v)
+			case float64:
+				id = int32(v)
+			default:
+				t.Fatalf("unexpected id type %T", row["id"])
+			}
+			score, _ := row["score"].(float64)
+			if score != want[id] {
+				t.Errorf("id=%d score = %v, want %v", id, score, want[id])
+			}
+		}
+	})
+
+	t.Run("FunctionCallExpression", func(t *testing.T) {
+		// upper(name) — another expression that the JSON-literal Update
+		// path cannot represent. Verifies that arbitrary scalar UDFs
+		// reach the DataFusion planner intact.
+		table := seed(t, "update_expr_func")
+		res, err := table.UpdateExpr(context.Background(), "id = 1",
+			[]contracts.UpdateAssignment{
+				{Column: "name", Expr: "upper(name)"},
+			})
+		if err != nil {
+			t.Fatalf("UpdateExpr: %v", err)
+		}
+		if res.RowsUpdated != 1 {
+			t.Errorf("RowsUpdated = %d, want 1", res.RowsUpdated)
+		}
+
+		rows, err := table.SelectWithFilter(context.Background(), "id = 1")
+		if err != nil {
+			t.Fatalf("SelectWithFilter: %v", err)
+		}
+		if len(rows) != 1 {
+			t.Fatalf("row count = %d, want 1", len(rows))
+		}
+		if got, _ := rows[0]["name"].(string); got != "ALICE" {
+			t.Errorf("name = %q, want %q", got, "ALICE")
+		}
+	})
+
+	t.Run("EmptyFilterUpdatesEveryRow", func(t *testing.T) {
+		table := seed(t, "update_expr_no_filter")
+		res, err := table.UpdateExpr(context.Background(), "",
+			[]contracts.UpdateAssignment{
+				{Column: "score", Expr: "0"},
+			})
+		if err != nil {
+			t.Fatalf("UpdateExpr: %v", err)
+		}
+		if res.RowsUpdated != 5 {
+			t.Errorf("RowsUpdated = %d, want 5", res.RowsUpdated)
+		}
+
+		rows, err := table.SelectWithFilter(context.Background(), "score = 0")
+		if err != nil {
+			t.Fatalf("SelectWithFilter: %v", err)
+		}
+		if len(rows) != 5 {
+			t.Errorf("zero-score row count = %d, want 5", len(rows))
+		}
+	})
+
+	t.Run("MultipleAssignmentsPreserveOrder", func(t *testing.T) {
+		// Both columns updated in one call. Verifies that the JSON
+		// array→Vec path keeps both pairs and applies them in the same
+		// commit.
+		table := seed(t, "update_expr_multi")
+		res, err := table.UpdateExpr(context.Background(), "id = 2",
+			[]contracts.UpdateAssignment{
+				{Column: "name", Expr: "'multi'"},
+				{Column: "score", Expr: "999.5"},
+			})
+		if err != nil {
+			t.Fatalf("UpdateExpr: %v", err)
+		}
+		if res.RowsUpdated != 1 {
+			t.Errorf("RowsUpdated = %d, want 1", res.RowsUpdated)
+		}
+
+		rows, err := table.SelectWithFilter(context.Background(), "id = 2")
+		if err != nil || len(rows) != 1 {
+			t.Fatalf("SelectWithFilter: rows=%d err=%v", len(rows), err)
+		}
+		if got, _ := rows[0]["name"].(string); got != "multi" {
+			t.Errorf("name = %q, want %q", got, "multi")
+		}
+		if got, _ := rows[0]["score"].(float64); got != 999.5 {
+			t.Errorf("score = %v, want 999.5", got)
+		}
+	})
+
+	t.Run("EmptyAssignmentsRejected", func(t *testing.T) {
+		table := seed(t, "update_expr_empty_assign")
+		_, err := table.UpdateExpr(context.Background(), "id = 1", nil)
+		if err == nil {
+			t.Fatal("expected error for empty assignments")
+		}
+	})
+
+	t.Run("EmptyColumnNameRejected", func(t *testing.T) {
+		table := seed(t, "update_expr_empty_col")
+		_, err := table.UpdateExpr(context.Background(), "id = 1",
+			[]contracts.UpdateAssignment{{Column: "", Expr: "1"}})
+		if err == nil {
+			t.Fatal("expected error for empty column name")
+		}
+	})
+
+	t.Run("InvalidFilterReturnsError", func(t *testing.T) {
+		table := seed(t, "update_expr_bad_filter")
+		_, err := table.UpdateExpr(context.Background(), "this is not sql $$",
+			[]contracts.UpdateAssignment{{Column: "score", Expr: "1"}})
+		if err == nil {
+			t.Fatal("expected error for invalid filter")
+		}
+	})
+
+	t.Run("InvalidExpressionReturnsError", func(t *testing.T) {
+		// Reference a column that does not exist — DataFusion should
+		// return a binder error which the FFI surfaces as a normal Go
+		// error rather than a panic.
+		table := seed(t, "update_expr_bad_expr")
+		_, err := table.UpdateExpr(context.Background(), "id = 1",
+			[]contracts.UpdateAssignment{{Column: "score", Expr: "no_such_column + 1"}})
+		if err == nil {
+			t.Fatal("expected error for unknown column reference")
+		}
+	})
+
+	t.Run("ClosedTableReturnsError", func(t *testing.T) {
+		table := seed(t, "update_expr_closed")
+		if err := table.Close(); err != nil {
+			t.Fatalf("close: %v", err)
+		}
+		_, err := table.UpdateExpr(context.Background(), "id = 1",
+			[]contracts.UpdateAssignment{{Column: "score", Expr: "1"}})
+		if err == nil {
+			t.Fatal("expected error for update on closed table")
+		}
+	})
+}

--- a/pkg/tests/update_expr_test.go
+++ b/pkg/tests/update_expr_test.go
@@ -44,7 +44,11 @@ func TestUpdateExpr(t *testing.T) {
 
 	pool := memory.NewGoAllocator()
 
-	seed := func(t *testing.T, name string) contracts.ITable {
+	// Returns the seeded ITable plus the same backing object asserted to
+	// the optional ITableUpdateExpr extension. Sub-tests use the second
+	// return for UpdateExpr calls and the first for everything else
+	// (SelectWithFilter, Close, ...).
+	seed := func(t *testing.T, name string) (contracts.ITable, contracts.ITableUpdateExpr) {
 		t.Helper()
 		table, err := conn.CreateTable(context.Background(), name, schema)
 		if err != nil {
@@ -60,12 +64,16 @@ func TestUpdateExpr(t *testing.T) {
 		if err := table.Add(context.Background(), rec, nil); err != nil {
 			t.Fatalf("seed add: %v", err)
 		}
-		return table
+		updater, ok := table.(contracts.ITableUpdateExpr)
+		if !ok {
+			t.Fatalf("table does not implement contracts.ITableUpdateExpr")
+		}
+		return table, updater
 	}
 
 	t.Run("FilterAndStringLiteral", func(t *testing.T) {
-		table := seed(t, "update_expr_filter_literal")
-		res, err := table.UpdateExpr(context.Background(), "id > 3",
+		table, updater := seed(t, "update_expr_filter_literal")
+		res, err := updater.UpdateExpr(context.Background(), "id > 3",
 			[]contracts.UpdateAssignment{
 				{Column: "name", Expr: "'updated'"},
 			})
@@ -102,8 +110,8 @@ func TestUpdateExpr(t *testing.T) {
 		// JSON-literal Update path (it would auto-quote to `'score + 100'`
 		// and DataFusion would reject the cast). UpdateExpr forwards the
 		// expression verbatim so the per-row score doubles-plus-100 lands.
-		table := seed(t, "update_expr_sql")
-		res, err := table.UpdateExpr(context.Background(), "id <= 3",
+		table, updater := seed(t, "update_expr_sql")
+		res, err := updater.UpdateExpr(context.Background(), "id <= 3",
 			[]contracts.UpdateAssignment{
 				{Column: "score", Expr: "score + 100"},
 			})
@@ -148,8 +156,8 @@ func TestUpdateExpr(t *testing.T) {
 		// upper(name) — another expression that the JSON-literal Update
 		// path cannot represent. Verifies that arbitrary scalar UDFs
 		// reach the DataFusion planner intact.
-		table := seed(t, "update_expr_func")
-		res, err := table.UpdateExpr(context.Background(), "id = 1",
+		table, updater := seed(t, "update_expr_func")
+		res, err := updater.UpdateExpr(context.Background(), "id = 1",
 			[]contracts.UpdateAssignment{
 				{Column: "name", Expr: "upper(name)"},
 			})
@@ -173,8 +181,8 @@ func TestUpdateExpr(t *testing.T) {
 	})
 
 	t.Run("EmptyFilterUpdatesEveryRow", func(t *testing.T) {
-		table := seed(t, "update_expr_no_filter")
-		res, err := table.UpdateExpr(context.Background(), "",
+		table, updater := seed(t, "update_expr_no_filter")
+		res, err := updater.UpdateExpr(context.Background(), "",
 			[]contracts.UpdateAssignment{
 				{Column: "score", Expr: "0"},
 			})
@@ -198,8 +206,8 @@ func TestUpdateExpr(t *testing.T) {
 		// Both columns updated in one call. Verifies that the JSON
 		// array→Vec path keeps both pairs and applies them in the same
 		// commit.
-		table := seed(t, "update_expr_multi")
-		res, err := table.UpdateExpr(context.Background(), "id = 2",
+		table, updater := seed(t, "update_expr_multi")
+		res, err := updater.UpdateExpr(context.Background(), "id = 2",
 			[]contracts.UpdateAssignment{
 				{Column: "name", Expr: "'multi'"},
 				{Column: "score", Expr: "999.5"},
@@ -224,16 +232,16 @@ func TestUpdateExpr(t *testing.T) {
 	})
 
 	t.Run("EmptyAssignmentsRejected", func(t *testing.T) {
-		table := seed(t, "update_expr_empty_assign")
-		_, err := table.UpdateExpr(context.Background(), "id = 1", nil)
+		_, updater := seed(t, "update_expr_empty_assign")
+		_, err := updater.UpdateExpr(context.Background(), "id = 1", nil)
 		if err == nil {
 			t.Fatal("expected error for empty assignments")
 		}
 	})
 
 	t.Run("EmptyColumnNameRejected", func(t *testing.T) {
-		table := seed(t, "update_expr_empty_col")
-		_, err := table.UpdateExpr(context.Background(), "id = 1",
+		_, updater := seed(t, "update_expr_empty_col")
+		_, err := updater.UpdateExpr(context.Background(), "id = 1",
 			[]contracts.UpdateAssignment{{Column: "", Expr: "1"}})
 		if err == nil {
 			t.Fatal("expected error for empty column name")
@@ -241,8 +249,8 @@ func TestUpdateExpr(t *testing.T) {
 	})
 
 	t.Run("InvalidFilterReturnsError", func(t *testing.T) {
-		table := seed(t, "update_expr_bad_filter")
-		_, err := table.UpdateExpr(context.Background(), "this is not sql $$",
+		_, updater := seed(t, "update_expr_bad_filter")
+		_, err := updater.UpdateExpr(context.Background(), "this is not sql $$",
 			[]contracts.UpdateAssignment{{Column: "score", Expr: "1"}})
 		if err == nil {
 			t.Fatal("expected error for invalid filter")
@@ -253,8 +261,8 @@ func TestUpdateExpr(t *testing.T) {
 		// Reference a column that does not exist — DataFusion should
 		// return a binder error which the FFI surfaces as a normal Go
 		// error rather than a panic.
-		table := seed(t, "update_expr_bad_expr")
-		_, err := table.UpdateExpr(context.Background(), "id = 1",
+		_, updater := seed(t, "update_expr_bad_expr")
+		_, err := updater.UpdateExpr(context.Background(), "id = 1",
 			[]contracts.UpdateAssignment{{Column: "score", Expr: "no_such_column + 1"}})
 		if err == nil {
 			t.Fatal("expected error for unknown column reference")
@@ -262,11 +270,11 @@ func TestUpdateExpr(t *testing.T) {
 	})
 
 	t.Run("ClosedTableReturnsError", func(t *testing.T) {
-		table := seed(t, "update_expr_closed")
+		table, updater := seed(t, "update_expr_closed")
 		if err := table.Close(); err != nil {
 			t.Fatalf("close: %v", err)
 		}
-		_, err := table.UpdateExpr(context.Background(), "id = 1",
+		_, err := updater.UpdateExpr(context.Background(), "id = 1",
 			[]contracts.UpdateAssignment{{Column: "score", Expr: "1"}})
 		if err == nil {
 			t.Fatal("expected error for update on closed table")

--- a/rust/src/data.rs
+++ b/rust/src/data.rs
@@ -130,6 +130,164 @@ pub extern "C" fn simple_lancedb_table_update(
     }
 }
 
+/// Update rows using raw SQL expressions per column, with an optional
+/// predicate. Unlike `simple_lancedb_table_update`, the per-column values
+/// are passed through to lancedb's `UpdateBuilder.column(name, expr)`
+/// verbatim — the caller is responsible for quoting string literals
+/// (`'foo'`) and formatting vector literals (`[1.0, 2.0, ...]`). This
+/// matches the Rust `Table::update()` builder's semantics one-for-one and
+/// unlocks SQL expressions like `counter + 1` or `upper(name)` that the
+/// JSON-literal path cannot represent.
+///
+/// `predicate` may be NULL or empty to update every row (no WHERE).
+///
+/// `assignments_json` schema:
+/// ```json
+/// [
+///   {"column": "i",    "expr": "i + 1"},
+///   {"column": "name", "expr": "'foo'"}
+/// ]
+/// ```
+/// An array (not a map) preserves caller order and avoids `serde_json`
+/// `Map` ordering surprises across versions.
+///
+/// On success `result_json` is set to a CString containing
+/// `{"rows_updated": <u64>, "version": <u64>}` which the caller must free
+/// via `simple_lancedb_free_string`.
+#[no_mangle]
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+pub extern "C" fn simple_lancedb_table_update_expr(
+    table_handle: *mut c_void,
+    predicate: *const c_char,
+    assignments_json: *const c_char,
+    result_json: *mut *mut c_char,
+) -> *mut SimpleResult {
+    let result = std::panic::catch_unwind(|| -> SimpleResult {
+        if table_handle.is_null() || assignments_json.is_null() || result_json.is_null() {
+            return SimpleResult::error("Invalid null arguments".to_string());
+        }
+
+        // Empty / null predicate is the documented "update all rows" form.
+        // A null predicate ptr is allowed and treated identically to "".
+        let predicate_str = if predicate.is_null() {
+            String::new()
+        } else {
+            match from_c_str(predicate) {
+                Ok(s) => s,
+                Err(e) => return SimpleResult::error(format!("Invalid predicate: {}", e)),
+            }
+        };
+
+        let assignments_str = match from_c_str(assignments_json) {
+            Ok(s) => s,
+            Err(e) => return SimpleResult::error(format!("Invalid assignments JSON: {}", e)),
+        };
+
+        // Parse `[{"column":"...", "expr":"..."}]` while rejecting unknown
+        // shapes loudly — silent acceptance of a stray map or missing key
+        // would forward an empty SET clause to lancedb and quietly succeed
+        // with rows_updated=0.
+        let parsed: serde_json::Value = match serde_json::from_str(&assignments_str) {
+            Ok(v) => v,
+            Err(e) => {
+                return SimpleResult::error(format!("Failed to parse assignments JSON: {}", e))
+            }
+        };
+        let arr = match parsed.as_array() {
+            Some(a) => a,
+            None => {
+                return SimpleResult::error(
+                    "assignments JSON must be an array of {column, expr} objects".to_string(),
+                )
+            }
+        };
+        if arr.is_empty() {
+            return SimpleResult::error(
+                "at least one assignment must be specified".to_string(),
+            );
+        }
+        let mut pairs: Vec<(String, String)> = Vec::with_capacity(arr.len());
+        for (idx, item) in arr.iter().enumerate() {
+            let obj = match item.as_object() {
+                Some(o) => o,
+                None => {
+                    return SimpleResult::error(format!(
+                        "assignment #{} must be an object with `column` and `expr` keys",
+                        idx
+                    ))
+                }
+            };
+            let column = match obj.get("column").and_then(|v| v.as_str()) {
+                Some(s) if !s.is_empty() => s.to_string(),
+                _ => {
+                    return SimpleResult::error(format!(
+                        "assignment #{}: `column` must be a non-empty string",
+                        idx
+                    ))
+                }
+            };
+            let expr = match obj.get("expr").and_then(|v| v.as_str()) {
+                Some(s) => s.to_string(),
+                _ => {
+                    return SimpleResult::error(format!(
+                        "assignment #{}: `expr` must be a string",
+                        idx
+                    ))
+                }
+            };
+            pairs.push((column, expr));
+        }
+
+        let table = unsafe { &*(table_handle as *const lancedb::Table) };
+        let rt = get_simple_runtime();
+
+        let exec_result = rt.block_on(async {
+            let mut builder = table.update();
+            if !predicate_str.is_empty() {
+                builder = builder.only_if(predicate_str);
+            }
+            for (col, expr) in pairs {
+                builder = builder.column(col, expr);
+            }
+            builder.execute().await
+        });
+
+        match exec_result {
+            Ok(ur) => {
+                let payload = serde_json::json!({
+                    "rows_updated": ur.rows_updated,
+                    "version": ur.version,
+                });
+                let json_str = match serde_json::to_string(&payload) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        return SimpleResult::error(format!(
+                            "Failed to serialize UpdateResult: {}",
+                            e
+                        ))
+                    }
+                };
+                let cstr = match std::ffi::CString::new(json_str) {
+                    Ok(c) => c,
+                    Err(e) => {
+                        return SimpleResult::error(format!("Failed to build C string: {}", e))
+                    }
+                };
+                unsafe { *result_json = cstr.into_raw() };
+                SimpleResult::ok()
+            }
+            Err(e) => SimpleResult::error(format!("Failed to update rows: {}", e)),
+        }
+    });
+
+    match result {
+        Ok(res) => Box::into_raw(Box::new(res)),
+        Err(_) => Box::into_raw(Box::new(SimpleResult::error(
+            "Panic in simple_lancedb_table_update_expr".to_string(),
+        ))),
+    }
+}
+
 /// Add JSON data to a table (simple version)
 /// Converts JSON array of objects to Arrow RecordBatch and adds to table
 #[no_mangle]

--- a/rust/src/data.rs
+++ b/rust/src/data.rs
@@ -202,9 +202,7 @@ pub extern "C" fn simple_lancedb_table_update_expr(
             }
         };
         if arr.is_empty() {
-            return SimpleResult::error(
-                "at least one assignment must be specified".to_string(),
-            );
+            return SimpleResult::error("at least one assignment must be specified".to_string());
         }
         let mut pairs: Vec<(String, String)> = Vec::with_capacity(arr.len());
         for (idx, item) in arr.iter().enumerate() {


### PR DESCRIPTION
## Summary

Existing `Update` / `simple_lancedb_table_update` forces a non-empty
predicate and auto-quotes every value as a SQL string literal. That
is fine for setting concrete literals but cannot represent the
expression form Rust's `Table::update()` builder already supports —
`counter + 1`, `upper(name)`, `coalesce(other, 0)`, vector literals
written as `[1.0, 2.0, ...]::float[]`, etc. Callers wiring up a
PostgreSQL-style `UPDATE ... SET col = expr [WHERE ...]` surface
have nothing to forward those expressions through.

This PR adds a second, additive entry point that mirrors the Rust
builder one-for-one. Existing `Update` keeps working unchanged so
current users (examples, tests, doc snippets, downstream importers)
are untouched.

## Changes

**Rust FFI (`rust/src/data.rs`):**
- New `simple_lancedb_table_update_expr(handle, predicate, assignments_json, result_json)`.
- `predicate` may be NULL or empty to update every row.
- Assignments are passed as a JSON array of `{column, expr}` objects so
  caller order is preserved and the new shape cannot be confused with
  the old map-based payload.
- `expr` is forwarded verbatim — the caller quotes string literals
  and formats vector literals.
- Returns `{rows_updated, version}` via a `result_json` out-param,
  matching the existing `merge_insert_ipc` pattern.

**Go contracts (`pkg/contracts/`):**
- `ITable.UpdateExpr(ctx, filter, []UpdateAssignment) (*UpdateResult, error)`.
- New `UpdateAssignment` and `UpdateResult` types with serde-mirrored JSON tags.

**Go internal (`pkg/internal/table.go`):**
- `Table.UpdateExpr` mirrors `Update`'s CString lifecycle, plus an
  empty-assignments / empty-column guard matching the Rust
  builder's own preconditions, plus the `result_json` parse + free.

**Tests (`pkg/tests/update_expr_test.go`):**
- 10 sub-tests exercise the new surface against a seeded table:
  filter + string literal, SQL expression reading the current value,
  function-call expression, no-filter all-rows update, multi-assignment
  ordering, plus four error paths (empty assignments, empty column,
  invalid filter, unknown column reference, closed table). All
  verify `rows_updated` and `version` round-trip.

**Generated header (`include/lancedb.h`):**
- `cbindgen 0.29.2` output regenerated by `scripts/build-native.sh`.