### PR TITLE
feat: expose Table schema-evolution (add/alter/drop columns) through the FFI

### DIFF
--- a/include/lancedb.h
+++ b/include/lancedb.h
@@ -335,6 +335,49 @@ struct SimpleResult *simple_lancedb_table_tags_update(void *table_handle,
                                                       uint64_t version);
 
 /**
+ * Add new columns to the table by evaluating SQL expressions over
+ * existing rows. `transforms_json` is a JSON array of
+ * {"name": "<col>", "expression": "<sql>"} objects. Empty arrays are
+ * rejected as a caller bug — adding zero columns is a no-op that
+ * almost always indicates a missing argument.
+ *
+ * On success, the new commit version is written to *version_out. A
+ * version of 0 indicates compatibility with legacy backends that do
+ * not report a commit version (mirrors AddColumnsResult::version
+ * semantics in lancedb).
+ */
+struct SimpleResult *simple_lancedb_table_add_columns(void *table_handle,
+                                                      const char *transforms_json,
+                                                      uint64_t *version_out);
+
+/**
+ * Alter existing columns — rename and/or change nullability.
+ * `alterations_json` is a JSON array of {"path": "<col>", "rename":
+ * "<new>", "nullable": <bool>} objects; rename and nullable are both
+ * optional and "unset" means "leave that attribute alone". Empty
+ * arrays are rejected.
+ *
+ * data_type casts are intentionally not exposed in v1 — they require
+ * Arrow DataType serialization and are slated for a follow-up. Callers
+ * who need a cast can drop and re-add the column through add_columns.
+ *
+ * On success, the new commit version is written to *version_out.
+ */
+struct SimpleResult *simple_lancedb_table_alter_columns(void *table_handle,
+                                                        const char *alterations_json,
+                                                        uint64_t *version_out);
+
+/**
+ * Drop columns from the table. `columns_json` is a JSON array of
+ * strings naming the columns to remove. Empty arrays are rejected.
+ *
+ * On success, the new commit version is written to *version_out.
+ */
+struct SimpleResult *simple_lancedb_table_drop_columns(void *table_handle,
+                                                       const char *columns_json,
+                                                       uint64_t *version_out);
+
+/**
  * Create a table with a simple JSON schema
  */
 struct SimpleResult *simple_lancedb_create_table(void *handle,

--- a/pkg/contracts/i_table.go
+++ b/pkg/contracts/i_table.go
@@ -290,5 +290,13 @@ type ITableSchemaEvolve interface {
 	// underlying bytes are reclaimed on the next OptimizeCompact.
 	// Returns the new commit version. An empty names slice is
 	// rejected; empty/whitespace-only names are rejected per-entry.
+	//
+	// Cascade behavior: any indexes whose only columns are dropped
+	// are removed as well — the caller does not need to DropIndex
+	// first. This is enforced by lance's Operation::Project commit
+	// path, which calls retain_relevant_indices when materializing
+	// the new manifest. Indexes covering a mix of dropped and
+	// surviving columns are not currently exercised here; assume
+	// they may be invalidated and rebuild explicitly if needed.
 	DropColumns(ctx context.Context, names []string) (uint64, error)
 }

--- a/pkg/contracts/i_table.go
+++ b/pkg/contracts/i_table.go
@@ -241,3 +241,54 @@ type ITableTimeTravel interface {
 	// the tag does not exist or the version is unknown.
 	TagUpdate(ctx context.Context, tag string, version uint64) error
 }
+
+// ITableSchemaEvolve is an optional capability extension layered on
+// top of ITable. It exposes lancedb's schema-evolution surface — adding
+// derived columns, renaming columns, toggling nullability, and
+// dropping columns. Each operation is a metadata commit (drop_columns
+// in particular only updates the manifest; the on-disk bytes are
+// reclaimed on the next compaction).
+//
+// Kept out of ITable so adding the capability to a downstream backend
+// (or removing it later) is not a source-breaking change for existing
+// ITable mocks/stubs. Callers detect the capability with a type
+// assertion:
+//
+//	if se, ok := table.(contracts.ITableSchemaEvolve); ok {
+//	    res, err := se.AddColumns(ctx, []NewColumnTransform{
+//	        {Name: "score_x2", Expression: "score * 2"},
+//	    })
+//	}
+//
+// Scope (v1):
+//   - AddColumns supports only the SqlExpressions transform
+//     (lance::dataset::NewColumnTransform::SqlExpressions). The
+//     BatchUDF / Stream / Reader / AllNulls variants are not exposed
+//     because they require closures or full Arrow IPC plumbing across
+//     the FFI boundary.
+//   - AlterColumns supports rename and nullable changes only. The
+//     data_type cast variant is deliberately deferred — it requires
+//     Arrow DataType serialization. Until then, callers needing a
+//     cast must AddColumns(<new-with-cast-expr>) → DropColumns(<old>).
+//   - DropColumns is the full surface.
+//
+// The shipped *internal.Table implements this interface.
+type ITableSchemaEvolve interface {
+	// AddColumns adds new columns to the table by evaluating SQL
+	// expressions over existing rows. Returns the new commit version.
+	// An empty transforms slice is rejected — adding zero columns is
+	// a no-op and almost always a caller bug.
+	AddColumns(ctx context.Context, transforms []NewColumnTransform) (uint64, error)
+
+	// AlterColumns renames columns and/or toggles their nullability.
+	// Returns the new commit version. Each entry must change at least
+	// one attribute; a no-op alteration is rejected. An empty
+	// alterations slice is rejected.
+	AlterColumns(ctx context.Context, alterations []ColumnAlteration) (uint64, error)
+
+	// DropColumns removes the named columns from the table. The
+	// underlying bytes are reclaimed on the next OptimizeCompact.
+	// Returns the new commit version. An empty names slice is
+	// rejected; empty/whitespace-only names are rejected per-entry.
+	DropColumns(ctx context.Context, names []string) (uint64, error)
+}

--- a/pkg/contracts/types.go
+++ b/pkg/contracts/types.go
@@ -347,3 +347,31 @@ type TagInfo struct {
 	ManifestSize uint64 `json:"manifest_size"`
 	Branch       string `json:"branch,omitempty"`
 }
+
+// NewColumnTransform describes one new column to derive from existing
+// rows via a SQL expression. Mirrors the SqlExpressions variant of
+// lance::dataset::NewColumnTransform — the only variant exposed
+// through the FFI in v1.
+//
+// Name is the new column's name. Expression is a SQL expression
+// evaluated against existing columns to produce the values; e.g.
+// `score * 2`, `date_trunc('day', ts)`, `coalesce(other, 0)`.
+type NewColumnTransform struct {
+	Name       string `json:"name"`
+	Expression string `json:"expression"`
+}
+
+// ColumnAlteration describes one in-place change to an existing
+// column. Mirrors the rename + nullable subset of
+// lance::dataset::ColumnAlteration. The data_type cast variant is
+// deliberately not exposed in v1.
+//
+// Path is the existing column's name. Rename, when non-nil, sets a
+// new name. Nullable, when non-nil, toggles the column's nullability.
+// At least one of Rename or Nullable must be set per entry — an
+// alteration with neither is rejected as a caller bug.
+type ColumnAlteration struct {
+	Path     string  `json:"path"`
+	Rename   *string `json:"rename,omitempty"`
+	Nullable *bool   `json:"nullable,omitempty"`
+}

--- a/pkg/internal/table_schema_evolve.go
+++ b/pkg/internal/table_schema_evolve.go
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The LanceDB Authors
+
+package internal
+
+/*
+#cgo CFLAGS: -I${SRCDIR}/../../include
+#include "lancedb.h"
+*/
+import "C"
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"unsafe"
+
+	"github.com/lancedb/lancedb-go/pkg/contracts"
+)
+
+// Compile-time check that *Table implements the optional
+// schema-evolution capability extension.
+var _ contracts.ITableSchemaEvolve = (*Table)(nil)
+
+// AddColumns adds new columns to the table by evaluating SQL
+// expressions over existing rows. Empty transforms slices, empty
+// names, and empty expressions are rejected on the Go side before
+// crossing the FFI to keep error messages local and predictable.
+func (t *Table) AddColumns(_ context.Context, transforms []contracts.NewColumnTransform) (uint64, error) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	if t.closed || t.handle == nil {
+		return 0, fmt.Errorf("table is closed")
+	}
+	if len(transforms) == 0 {
+		return 0, fmt.Errorf("add_columns: transforms must be non-empty")
+	}
+	for i, tr := range transforms {
+		if strings.TrimSpace(tr.Name) == "" {
+			return 0, fmt.Errorf("add_columns: transforms[%d].Name is empty", i)
+		}
+		if strings.TrimSpace(tr.Expression) == "" {
+			return 0, fmt.Errorf("add_columns: transforms[%d].Expression is empty", i)
+		}
+	}
+
+	payload, err := json.Marshal(transforms)
+	if err != nil {
+		return 0, fmt.Errorf("add_columns: marshal transforms: %w", err)
+	}
+	cJSON := C.CString(string(payload))
+	// #nosec G103 - Required for freeing C allocated string memory
+	defer C.free(unsafe.Pointer(cJSON))
+
+	var version C.uint64_t
+	result := C.simple_lancedb_table_add_columns(t.handle, cJSON, &version)
+	defer C.simple_lancedb_result_free(result)
+
+	if !result.SUCCESS {
+		if result.ERROR_MESSAGE != nil {
+			return 0, fmt.Errorf("failed to add columns: %s", C.GoString(result.ERROR_MESSAGE))
+		}
+		return 0, fmt.Errorf("failed to add columns: unknown error")
+	}
+	return uint64(version), nil
+}
+
+// AlterColumns renames columns and/or toggles their nullability.
+// Each entry must change at least one attribute — alterations with
+// neither rename nor nullable set are rejected as caller bugs (the
+// backend would otherwise produce a no-op commit).
+func (t *Table) AlterColumns(_ context.Context, alterations []contracts.ColumnAlteration) (uint64, error) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	if t.closed || t.handle == nil {
+		return 0, fmt.Errorf("table is closed")
+	}
+	if len(alterations) == 0 {
+		return 0, fmt.Errorf("alter_columns: alterations must be non-empty")
+	}
+	for i, a := range alterations {
+		if strings.TrimSpace(a.Path) == "" {
+			return 0, fmt.Errorf("alter_columns: alterations[%d].Path is empty", i)
+		}
+		if a.Rename == nil && a.Nullable == nil {
+			return 0, fmt.Errorf("alter_columns: alterations[%d] has no rename or nullable change", i)
+		}
+		if a.Rename != nil && strings.TrimSpace(*a.Rename) == "" {
+			return 0, fmt.Errorf("alter_columns: alterations[%d].Rename is empty string", i)
+		}
+	}
+
+	payload, err := json.Marshal(alterations)
+	if err != nil {
+		return 0, fmt.Errorf("alter_columns: marshal alterations: %w", err)
+	}
+	cJSON := C.CString(string(payload))
+	// #nosec G103 - Required for freeing C allocated string memory
+	defer C.free(unsafe.Pointer(cJSON))
+
+	var version C.uint64_t
+	result := C.simple_lancedb_table_alter_columns(t.handle, cJSON, &version)
+	defer C.simple_lancedb_result_free(result)
+
+	if !result.SUCCESS {
+		if result.ERROR_MESSAGE != nil {
+			return 0, fmt.Errorf("failed to alter columns: %s", C.GoString(result.ERROR_MESSAGE))
+		}
+		return 0, fmt.Errorf("failed to alter columns: unknown error")
+	}
+	return uint64(version), nil
+}
+
+// DropColumns removes the named columns from the table. The on-disk
+// bytes are reclaimed on the next OptimizeCompact — DropColumns itself
+// only updates the manifest.
+func (t *Table) DropColumns(_ context.Context, names []string) (uint64, error) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	if t.closed || t.handle == nil {
+		return 0, fmt.Errorf("table is closed")
+	}
+	if len(names) == 0 {
+		return 0, fmt.Errorf("drop_columns: names must be non-empty")
+	}
+	for i, n := range names {
+		if strings.TrimSpace(n) == "" {
+			return 0, fmt.Errorf("drop_columns: names[%d] is empty", i)
+		}
+	}
+
+	payload, err := json.Marshal(names)
+	if err != nil {
+		return 0, fmt.Errorf("drop_columns: marshal names: %w", err)
+	}
+	cJSON := C.CString(string(payload))
+	// #nosec G103 - Required for freeing C allocated string memory
+	defer C.free(unsafe.Pointer(cJSON))
+
+	var version C.uint64_t
+	result := C.simple_lancedb_table_drop_columns(t.handle, cJSON, &version)
+	defer C.simple_lancedb_result_free(result)
+
+	if !result.SUCCESS {
+		if result.ERROR_MESSAGE != nil {
+			return 0, fmt.Errorf("failed to drop columns: %s", C.GoString(result.ERROR_MESSAGE))
+		}
+		return 0, fmt.Errorf("failed to drop columns: unknown error")
+	}
+	return uint64(version), nil
+}

--- a/pkg/tests/schema_evolve_test.go
+++ b/pkg/tests/schema_evolve_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/apache/arrow/go/v17/arrow/memory"
@@ -394,6 +395,58 @@ func TestSchemaEvolve(t *testing.T) {
 		for _, n := range got {
 			if !want[n] {
 				t.Errorf("unexpected field after round-trip: %q", n)
+			}
+		}
+	})
+
+	// Property: dropping a column that has an index also clears that
+	// index from the table's index list. Lance handles this in the
+	// Operation::Project commit path via retain_relevant_indices —
+	// no explicit DropIndex call is required from the caller.
+	t.Run("DropColumnsCascadesToIndex", func(t *testing.T) {
+		table, se := seed(t, "se_drop_cascades_index")
+
+		// Build a scalar index on `score`; BTree is the cheapest to
+		// build on a 5-row table.
+		if err := table.CreateIndex(context.Background(),
+			[]string{"score"}, contracts.IndexTypeBTree); err != nil {
+			t.Fatalf("CreateIndex(BTree, score): %v", err)
+		}
+		// Wait for the index to be ready before checking GetAllIndexes
+		// — index build is async on the backend.
+		if err := table.WaitForIndex(context.Background(), nil, 30*time.Second); err != nil {
+			t.Fatalf("WaitForIndex: %v", err)
+		}
+
+		before, err := table.GetAllIndexes(context.Background())
+		if err != nil {
+			t.Fatalf("GetAllIndexes (before drop): %v", err)
+		}
+		var hadScoreIdx bool
+		for _, ix := range before {
+			for _, c := range ix.Columns {
+				if c == "score" {
+					hadScoreIdx = true
+				}
+			}
+		}
+		if !hadScoreIdx {
+			t.Fatalf("test precondition failed: no index on 'score' before drop. Indexes=%+v", before)
+		}
+
+		if _, err := se.DropColumns(context.Background(), []string{"score"}); err != nil {
+			t.Fatalf("DropColumns(score): %v", err)
+		}
+
+		after, err := table.GetAllIndexes(context.Background())
+		if err != nil {
+			t.Fatalf("GetAllIndexes (after drop): %v", err)
+		}
+		for _, ix := range after {
+			for _, c := range ix.Columns {
+				if c == "score" {
+					t.Errorf("index on dropped column 'score' still present: %+v", ix)
+				}
 			}
 		}
 	})

--- a/pkg/tests/schema_evolve_test.go
+++ b/pkg/tests/schema_evolve_test.go
@@ -1,0 +1,432 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The LanceDB Authors
+
+package tests
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/memory"
+
+	"github.com/lancedb/lancedb-go/pkg/contracts"
+	"github.com/lancedb/lancedb-go/pkg/internal"
+	"github.com/lancedb/lancedb-go/pkg/lancedb"
+)
+
+// TestSchemaEvolve exercises the AddColumns / AlterColumns /
+// DropColumns capability extension end-to-end. Each sub-test seeds a
+// fresh table so cases stay independent.
+func TestSchemaEvolve(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "lancedb_test_schema_evolve_")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	conn, err := lancedb.Connect(context.Background(), tempDir, nil)
+	if err != nil {
+		t.Fatalf("failed to connect: %v", err)
+	}
+	defer conn.Close()
+
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
+		{Name: "name", Type: arrow.BinaryTypes.String, Nullable: false},
+		{Name: "score", Type: arrow.PrimitiveTypes.Float64, Nullable: true},
+	}, nil)
+	schema, err := internal.NewSchema(arrowSchema)
+	if err != nil {
+		t.Fatalf("failed to create schema: %v", err)
+	}
+
+	pool := memory.NewGoAllocator()
+
+	// seed creates a fresh table named `name`, adds five rows, and
+	// returns it asserted to the schema-evolve capability extension.
+	seed := func(t *testing.T, name string) (contracts.ITable, contracts.ITableSchemaEvolve) {
+		t.Helper()
+		table, err := conn.CreateTable(context.Background(), name, schema)
+		if err != nil {
+			t.Fatalf("create table: %v", err)
+		}
+		t.Cleanup(func() { _ = table.Close() })
+
+		rec := buildRecord(t, pool, arrowSchema,
+			[]int32{1, 2, 3, 4, 5},
+			[]string{"Alice", "Bob", "Charlie", "Diana", "Eve"},
+			[]float64{10, 20, 30, 40, 50})
+		defer rec.Release()
+		if err := table.Add(context.Background(), rec, nil); err != nil {
+			t.Fatalf("seed add: %v", err)
+		}
+		se, ok := table.(contracts.ITableSchemaEvolve)
+		if !ok {
+			t.Fatalf("table does not implement contracts.ITableSchemaEvolve")
+		}
+		return table, se
+	}
+
+	hasField := func(t *testing.T, table contracts.ITable, name string) bool {
+		t.Helper()
+		s, err := table.Schema(context.Background())
+		if err != nil {
+			t.Fatalf("Schema: %v", err)
+		}
+		for _, f := range s.Fields() {
+			if f.Name == name {
+				return true
+			}
+		}
+		return false
+	}
+
+	fieldNullable := func(t *testing.T, table contracts.ITable, name string) bool {
+		t.Helper()
+		s, err := table.Schema(context.Background())
+		if err != nil {
+			t.Fatalf("Schema: %v", err)
+		}
+		for _, f := range s.Fields() {
+			if f.Name == name {
+				return f.Nullable
+			}
+		}
+		t.Fatalf("field %q not found", name)
+		return false
+	}
+
+	// Property: AddColumns of a single SQL expression yields a column
+	// whose values equal the expression evaluated against existing
+	// rows. We seed score = {10..50} and add score_x2 = score * 2,
+	// then verify each row.
+	t.Run("AddColumnsSqlExpressionProperty", func(t *testing.T) {
+		table, se := seed(t, "se_add_sql_expr_property")
+
+		ver, err := se.AddColumns(context.Background(),
+			[]contracts.NewColumnTransform{
+				{Name: "score_x2", Expression: "score * 2"},
+			})
+		if err != nil {
+			t.Fatalf("AddColumns: %v", err)
+		}
+		if ver == 0 {
+			t.Errorf("AddColumns returned version 0, want > 0")
+		}
+		if !hasField(t, table, "score_x2") {
+			t.Fatalf("schema is missing the newly added column score_x2")
+		}
+
+		rows, err := table.Select(context.Background(), contracts.QueryConfig{
+			Columns: []string{"score", "score_x2"},
+		})
+		if err != nil {
+			t.Fatalf("Select: %v", err)
+		}
+		if len(rows) != 5 {
+			t.Fatalf("Select returned %d rows, want 5", len(rows))
+		}
+		for i, r := range rows {
+			score, ok := r["score"].(float64)
+			if !ok {
+				t.Fatalf("row %d score has unexpected type %T", i, r["score"])
+			}
+			x2, ok := r["score_x2"].(float64)
+			if !ok {
+				t.Fatalf("row %d score_x2 has unexpected type %T", i, r["score_x2"])
+			}
+			if x2 != score*2 {
+				t.Errorf("row %d: score_x2=%v, want %v", i, x2, score*2)
+			}
+		}
+	})
+
+	t.Run("AddColumnsMultipleAtOnce", func(t *testing.T) {
+		table, se := seed(t, "se_add_multi")
+
+		_, err := se.AddColumns(context.Background(),
+			[]contracts.NewColumnTransform{
+				{Name: "id_plus_100", Expression: "id + 100"},
+				{Name: "score_div_10", Expression: "score / 10"},
+			})
+		if err != nil {
+			t.Fatalf("AddColumns: %v", err)
+		}
+		if !hasField(t, table, "id_plus_100") || !hasField(t, table, "score_div_10") {
+			t.Fatalf("AddColumns did not add both columns")
+		}
+	})
+
+	t.Run("AddColumnsRejectsBadInput", func(t *testing.T) {
+		_, se := seed(t, "se_add_bad_input")
+		// Empty slice.
+		if _, err := se.AddColumns(context.Background(), nil); err == nil {
+			t.Error("expected error for nil transforms")
+		}
+		if _, err := se.AddColumns(context.Background(), []contracts.NewColumnTransform{}); err == nil {
+			t.Error("expected error for empty transforms")
+		}
+		// Empty Name.
+		if _, err := se.AddColumns(context.Background(),
+			[]contracts.NewColumnTransform{{Name: "", Expression: "score * 2"}}); err == nil {
+			t.Error("expected error for empty Name")
+		}
+		// Whitespace-only Name.
+		if _, err := se.AddColumns(context.Background(),
+			[]contracts.NewColumnTransform{{Name: "   ", Expression: "score * 2"}}); err == nil {
+			t.Error("expected error for whitespace-only Name")
+		}
+		// Empty Expression.
+		if _, err := se.AddColumns(context.Background(),
+			[]contracts.NewColumnTransform{{Name: "x", Expression: ""}}); err == nil {
+			t.Error("expected error for empty Expression")
+		}
+		// Duplicate of an existing column — backend error.
+		if _, err := se.AddColumns(context.Background(),
+			[]contracts.NewColumnTransform{{Name: "id", Expression: "id + 0"}}); err == nil {
+			t.Error("expected backend error for duplicate column id")
+		}
+		// Bad SQL expression — backend error.
+		if _, err := se.AddColumns(context.Background(),
+			[]contracts.NewColumnTransform{{Name: "bad", Expression: "this is not sql !!!"}}); err == nil {
+			t.Error("expected backend error for malformed SQL expression")
+		}
+	})
+
+	// Property: rename preserves data and row count; only the field
+	// name changes.
+	t.Run("AlterColumnsRename", func(t *testing.T) {
+		table, se := seed(t, "se_alter_rename")
+		newName := "score_renamed"
+
+		ver, err := se.AlterColumns(context.Background(),
+			[]contracts.ColumnAlteration{{Path: "score", Rename: &newName}})
+		if err != nil {
+			t.Fatalf("AlterColumns rename: %v", err)
+		}
+		if ver == 0 {
+			t.Errorf("AlterColumns returned version 0, want > 0")
+		}
+		if hasField(t, table, "score") {
+			t.Errorf("old column 'score' still present after rename")
+		}
+		if !hasField(t, table, newName) {
+			t.Errorf("new column %q not present after rename", newName)
+		}
+		count, err := table.Count(context.Background())
+		if err != nil {
+			t.Fatalf("Count: %v", err)
+		}
+		if count != 5 {
+			t.Errorf("row count drifted across rename: got %d, want 5", count)
+		}
+	})
+
+	t.Run("AlterColumnsNullableToggle", func(t *testing.T) {
+		// Loosen nullability (false -> true) on `id`. Lance only
+		// allows widening, not tightening — a separate sub-test below
+		// verifies that tightening is rejected.
+		table, se := seed(t, "se_alter_nullable_loosen")
+		if fieldNullable(t, table, "id") {
+			t.Fatalf("test precondition: id should start non-nullable")
+		}
+		nullable := true
+		if _, err := se.AlterColumns(context.Background(),
+			[]contracts.ColumnAlteration{{Path: "id", Nullable: &nullable}}); err != nil {
+			t.Fatalf("AlterColumns nullable=true: %v", err)
+		}
+		if !fieldNullable(t, table, "id") {
+			t.Errorf("id not nullable after toggle to true")
+		}
+	})
+
+	t.Run("AlterColumnsNullableTighteningRejected", func(t *testing.T) {
+		// Tightening nullability (true -> false) on a column that is
+		// already nullable is rejected by lance even when no NULLs
+		// exist — a documented backend policy. The error must surface
+		// as a regular Go error, not a panic or silent success.
+		_, se := seed(t, "se_alter_nullable_tighten")
+		nullable := false
+		_, err := se.AlterColumns(context.Background(),
+			[]contracts.ColumnAlteration{{Path: "score", Nullable: &nullable}})
+		if err == nil {
+			t.Error("expected backend to reject nullable=false on already-nullable column")
+		}
+	})
+
+	t.Run("AlterColumnsRejectsBadInput", func(t *testing.T) {
+		_, se := seed(t, "se_alter_bad_input")
+		// Empty slice.
+		if _, err := se.AlterColumns(context.Background(), nil); err == nil {
+			t.Error("expected error for nil alterations")
+		}
+		// Empty path.
+		newName := "x"
+		if _, err := se.AlterColumns(context.Background(),
+			[]contracts.ColumnAlteration{{Path: "", Rename: &newName}}); err == nil {
+			t.Error("expected error for empty Path")
+		}
+		// No rename and no nullable.
+		if _, err := se.AlterColumns(context.Background(),
+			[]contracts.ColumnAlteration{{Path: "score"}}); err == nil {
+			t.Error("expected error for alteration with neither rename nor nullable")
+		}
+		// Empty rename string.
+		empty := ""
+		if _, err := se.AlterColumns(context.Background(),
+			[]contracts.ColumnAlteration{{Path: "score", Rename: &empty}}); err == nil {
+			t.Error("expected error for empty rename string")
+		}
+		// Unknown column — backend error.
+		if _, err := se.AlterColumns(context.Background(),
+			[]contracts.ColumnAlteration{{Path: "ghost", Rename: &newName}}); err == nil {
+			t.Error("expected backend error for unknown column")
+		}
+	})
+
+	// Property: drop removes the column from the schema while leaving
+	// row count and other columns untouched.
+	t.Run("DropColumnsBasic", func(t *testing.T) {
+		table, se := seed(t, "se_drop_basic")
+
+		ver, err := se.DropColumns(context.Background(), []string{"score"})
+		if err != nil {
+			t.Fatalf("DropColumns: %v", err)
+		}
+		if ver == 0 {
+			t.Errorf("DropColumns returned version 0, want > 0")
+		}
+		if hasField(t, table, "score") {
+			t.Errorf("column 'score' still present after drop")
+		}
+		if !hasField(t, table, "id") || !hasField(t, table, "name") {
+			t.Errorf("DropColumns dropped extra columns: schema=%v",
+				schemaFieldNames(t, table))
+		}
+		count, err := table.Count(context.Background())
+		if err != nil {
+			t.Fatalf("Count: %v", err)
+		}
+		if count != 5 {
+			t.Errorf("row count drifted across drop: got %d, want 5", count)
+		}
+	})
+
+	t.Run("DropColumnsMultiple", func(t *testing.T) {
+		table, se := seed(t, "se_drop_multi")
+		_, err := se.DropColumns(context.Background(), []string{"name", "score"})
+		if err != nil {
+			t.Fatalf("DropColumns(multi): %v", err)
+		}
+		if hasField(t, table, "name") || hasField(t, table, "score") {
+			t.Errorf("DropColumns(multi) did not remove both columns")
+		}
+	})
+
+	t.Run("DropColumnsRejectsBadInput", func(t *testing.T) {
+		_, se := seed(t, "se_drop_bad_input")
+		if _, err := se.DropColumns(context.Background(), nil); err == nil {
+			t.Error("expected error for nil names")
+		}
+		if _, err := se.DropColumns(context.Background(), []string{}); err == nil {
+			t.Error("expected error for empty names")
+		}
+		if _, err := se.DropColumns(context.Background(), []string{""}); err == nil {
+			t.Error("expected error for empty name entry")
+		}
+		if _, err := se.DropColumns(context.Background(), []string{"   "}); err == nil {
+			t.Error("expected error for whitespace-only name entry")
+		}
+		if _, err := se.DropColumns(context.Background(), []string{"ghost"}); err == nil {
+			t.Error("expected backend error for unknown column")
+		}
+	})
+
+	// Round-trip: Add → Alter (rename) → Drop returns the schema to
+	// its original field set, and each successful op bumps the table
+	// version monotonically.
+	t.Run("AddAlterDropRoundTrip", func(t *testing.T) {
+		table, se := seed(t, "se_round_trip")
+
+		v0, err := table.Version(context.Background())
+		if err != nil {
+			t.Fatalf("Version v0: %v", err)
+		}
+
+		if _, err := se.AddColumns(context.Background(),
+			[]contracts.NewColumnTransform{{Name: "tmp", Expression: "score * 2"}}); err != nil {
+			t.Fatalf("AddColumns: %v", err)
+		}
+		v1, _ := table.Version(context.Background())
+		if v1 <= v0 {
+			t.Errorf("version did not advance after AddColumns: v0=%d v1=%d", v0, v1)
+		}
+
+		newName := "tmp_renamed"
+		if _, err := se.AlterColumns(context.Background(),
+			[]contracts.ColumnAlteration{{Path: "tmp", Rename: &newName}}); err != nil {
+			t.Fatalf("AlterColumns: %v", err)
+		}
+		v2, _ := table.Version(context.Background())
+		if v2 <= v1 {
+			t.Errorf("version did not advance after AlterColumns: v1=%d v2=%d", v1, v2)
+		}
+		if hasField(t, table, "tmp") || !hasField(t, table, "tmp_renamed") {
+			t.Fatalf("rename did not take effect")
+		}
+
+		if _, err := se.DropColumns(context.Background(), []string{"tmp_renamed"}); err != nil {
+			t.Fatalf("DropColumns: %v", err)
+		}
+		v3, _ := table.Version(context.Background())
+		if v3 <= v2 {
+			t.Errorf("version did not advance after DropColumns: v2=%d v3=%d", v2, v3)
+		}
+		// Schema must match the original {id, name, score}.
+		got := schemaFieldNames(t, table)
+		want := map[string]bool{"id": true, "name": true, "score": true}
+		if len(got) != len(want) {
+			t.Fatalf("post-roundtrip field count = %d, want %d (got=%v)",
+				len(got), len(want), got)
+		}
+		for _, n := range got {
+			if !want[n] {
+				t.Errorf("unexpected field after round-trip: %q", n)
+			}
+		}
+	})
+
+	t.Run("ClosedTableReturnsError", func(t *testing.T) {
+		table, se := seed(t, "se_closed")
+		if err := table.Close(); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+		if _, err := se.AddColumns(context.Background(),
+			[]contracts.NewColumnTransform{{Name: "x", Expression: "1"}}); err == nil {
+			t.Error("expected AddColumns on closed table to fail")
+		}
+		newName := "x"
+		if _, err := se.AlterColumns(context.Background(),
+			[]contracts.ColumnAlteration{{Path: "score", Rename: &newName}}); err == nil {
+			t.Error("expected AlterColumns on closed table to fail")
+		}
+		if _, err := se.DropColumns(context.Background(), []string{"score"}); err == nil {
+			t.Error("expected DropColumns on closed table to fail")
+		}
+	})
+}
+
+func schemaFieldNames(t *testing.T, table contracts.ITable) []string {
+	t.Helper()
+	s, err := table.Schema(context.Background())
+	if err != nil {
+		t.Fatalf("Schema: %v", err)
+	}
+	out := make([]string, 0, len(s.Fields()))
+	for _, f := range s.Fields() {
+		out = append(out, f.Name)
+	}
+	return out
+}

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3995,6 +3995,7 @@ dependencies = [
  "lancedb",
  "libc",
  "log",
+ "serde",
  "serde_json",
  "tokio",
  "tokio-stream",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -29,6 +29,7 @@ arrow-schema = "56.2"
 arrow-ord = "56.2"
 arrow-cast = "56.2"
 arrow-ipc = "56.2"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio-stream = "0.1"
 # Re-exported via lancedb::table::OptimizeAction::Prune.older_than.

--- a/rust/cbindgen.toml
+++ b/rust/cbindgen.toml
@@ -44,6 +44,9 @@ include = [
     "simple_lancedb_table_tags_create",
     "simple_lancedb_table_tags_delete",
     "simple_lancedb_table_tags_update",
+    "simple_lancedb_table_add_columns",
+    "simple_lancedb_table_alter_columns",
+    "simple_lancedb_table_drop_columns",
     "simple_lancedb_result_free",
     "simple_lancedb_free_string",
 ]

--- a/rust/src/lib_simple.rs
+++ b/rust/src/lib_simple.rs
@@ -14,6 +14,7 @@ pub mod query;
 pub mod refs;
 pub mod runtime;
 pub mod schema;
+pub mod schema_evolve;
 pub mod table;
 pub mod types;
 
@@ -26,5 +27,6 @@ pub use index::*;
 pub use metadata::*;
 pub use query::*;
 pub use refs::*;
+pub use schema_evolve::*;
 pub use table::*;
 pub use types::*;

--- a/rust/src/schema_evolve.rs
+++ b/rust/src/schema_evolve.rs
@@ -76,7 +76,9 @@ pub extern "C" fn simple_lancedb_table_add_columns(
         };
         let entries: Vec<SqlExprEntry> = match serde_json::from_str(&json) {
             Ok(v) => v,
-            Err(e) => return SimpleResult::error(format!("Failed to parse transforms_json: {}", e)),
+            Err(e) => {
+                return SimpleResult::error(format!("Failed to parse transforms_json: {}", e))
+            }
         };
         if entries.is_empty() {
             return SimpleResult::error(

--- a/rust/src/schema_evolve.rs
+++ b/rust/src/schema_evolve.rs
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The LanceDB Authors
+
+//! Schema-evolution surface — add / alter / drop columns.
+//!
+//! Mirrors the same SimpleResult + panic-safe + shared-runtime envelope
+//! used by the rest of the simple FFI. Inputs that carry structured
+//! payloads (the SqlExpressions transform list, the alteration list,
+//! the drop names) come in as JSON strings; outputs (commit version)
+//! come back through scalar out-pointers.
+//!
+//! Scope (v1):
+//!   - add_columns: NewColumnTransform::SqlExpressions only.
+//!     BatchUDF / Stream / Reader / AllNulls are not exposed because
+//!     they require either Rust closures or full Arrow IPC plumbing.
+//!     SqlExpressions covers the common "derive from existing columns"
+//!     case (e.g. `score * 2`, `date_trunc('day', ts)`) and is the only
+//!     transform reachable from Python's `add_columns(transforms=dict)`.
+//!   - alter_columns: rename + nullable only. The data_type cast
+//!     variant is gated behind Arrow DataType serialization and is
+//!     deliberately deferred to a follow-up PR.
+//!   - drop_columns: full surface — just a list of column names.
+
+use crate::ffi::{from_c_str, SimpleResult};
+use crate::runtime::get_simple_runtime;
+use lancedb::table::{ColumnAlteration, NewColumnTransform};
+use serde::Deserialize;
+use std::os::raw::{c_char, c_void};
+
+/// One entry in the SqlExpressions transform list. `name` is the new
+/// column to create; `expression` is a SQL expression evaluated against
+/// existing columns to produce its values.
+#[derive(Debug, Deserialize)]
+struct SqlExprEntry {
+    name: String,
+    expression: String,
+}
+
+/// JSON shape expected by simple_lancedb_table_alter_columns. Mirrors
+/// lance::dataset::ColumnAlteration with the fields actually exposed in
+/// v1 (rename, nullable). The `path` field maps to ColumnAlteration's
+/// path. Unset rename / nullable mean "leave unchanged".
+#[derive(Debug, Deserialize)]
+struct AlterEntry {
+    path: String,
+    #[serde(default)]
+    rename: Option<String>,
+    #[serde(default)]
+    nullable: Option<bool>,
+}
+
+/// Add new columns to the table by evaluating SQL expressions over
+/// existing rows. `transforms_json` is a JSON array of
+/// {"name": "<col>", "expression": "<sql>"} objects. Empty arrays are
+/// rejected as a caller bug — adding zero columns is a no-op that
+/// almost always indicates a missing argument.
+///
+/// On success, the new commit version is written to *version_out. A
+/// version of 0 indicates compatibility with legacy backends that do
+/// not report a commit version (mirrors AddColumnsResult::version
+/// semantics in lancedb).
+#[no_mangle]
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+pub extern "C" fn simple_lancedb_table_add_columns(
+    table_handle: *mut c_void,
+    transforms_json: *const c_char,
+    version_out: *mut u64,
+) -> *mut SimpleResult {
+    let result = std::panic::catch_unwind(|| -> SimpleResult {
+        if table_handle.is_null() || transforms_json.is_null() || version_out.is_null() {
+            return SimpleResult::error("Invalid null arguments".to_string());
+        }
+        let json = match from_c_str(transforms_json) {
+            Ok(s) => s,
+            Err(e) => return SimpleResult::error(format!("Invalid transforms_json: {}", e)),
+        };
+        let entries: Vec<SqlExprEntry> = match serde_json::from_str(&json) {
+            Ok(v) => v,
+            Err(e) => return SimpleResult::error(format!("Failed to parse transforms_json: {}", e)),
+        };
+        if entries.is_empty() {
+            return SimpleResult::error(
+                "add_columns: transforms must be a non-empty array".to_string(),
+            );
+        }
+
+        let pairs: Vec<(String, String)> = entries
+            .into_iter()
+            .map(|e| (e.name, e.expression))
+            .collect();
+        let transforms = NewColumnTransform::SqlExpressions(pairs);
+
+        let table = unsafe { &*(table_handle as *const lancedb::Table) };
+        let rt = get_simple_runtime();
+        match rt.block_on(async { table.add_columns(transforms, None).await }) {
+            Ok(res) => {
+                unsafe {
+                    *version_out = res.version;
+                }
+                SimpleResult::ok()
+            }
+            Err(e) => SimpleResult::error(format!("add_columns failed: {}", e)),
+        }
+    });
+
+    match result {
+        Ok(res) => Box::into_raw(Box::new(res)),
+        Err(_) => Box::into_raw(Box::new(SimpleResult::error(
+            "Panic in simple_lancedb_table_add_columns".to_string(),
+        ))),
+    }
+}
+
+/// Alter existing columns — rename and/or change nullability.
+/// `alterations_json` is a JSON array of {"path": "<col>", "rename":
+/// "<new>", "nullable": <bool>} objects; rename and nullable are both
+/// optional and "unset" means "leave that attribute alone". Empty
+/// arrays are rejected.
+///
+/// data_type casts are intentionally not exposed in v1 — they require
+/// Arrow DataType serialization and are slated for a follow-up. Callers
+/// who need a cast can drop and re-add the column through add_columns.
+///
+/// On success, the new commit version is written to *version_out.
+#[no_mangle]
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+pub extern "C" fn simple_lancedb_table_alter_columns(
+    table_handle: *mut c_void,
+    alterations_json: *const c_char,
+    version_out: *mut u64,
+) -> *mut SimpleResult {
+    let result = std::panic::catch_unwind(|| -> SimpleResult {
+        if table_handle.is_null() || alterations_json.is_null() || version_out.is_null() {
+            return SimpleResult::error("Invalid null arguments".to_string());
+        }
+        let json = match from_c_str(alterations_json) {
+            Ok(s) => s,
+            Err(e) => return SimpleResult::error(format!("Invalid alterations_json: {}", e)),
+        };
+        let entries: Vec<AlterEntry> = match serde_json::from_str(&json) {
+            Ok(v) => v,
+            Err(e) => {
+                return SimpleResult::error(format!("Failed to parse alterations_json: {}", e))
+            }
+        };
+        if entries.is_empty() {
+            return SimpleResult::error(
+                "alter_columns: alterations must be a non-empty array".to_string(),
+            );
+        }
+        for (i, e) in entries.iter().enumerate() {
+            if e.path.trim().is_empty() {
+                return SimpleResult::error(format!(
+                    "alter_columns: alterations[{}].path is empty",
+                    i
+                ));
+            }
+            if e.rename.is_none() && e.nullable.is_none() {
+                return SimpleResult::error(format!(
+                    "alter_columns: alterations[{}] has no rename or nullable change",
+                    i
+                ));
+            }
+        }
+
+        let alterations: Vec<ColumnAlteration> = entries
+            .into_iter()
+            .map(|e| {
+                let mut a = ColumnAlteration::new(e.path);
+                if let Some(new_name) = e.rename {
+                    a = a.rename(new_name);
+                }
+                if let Some(n) = e.nullable {
+                    a = a.set_nullable(n);
+                }
+                a
+            })
+            .collect();
+
+        let table = unsafe { &*(table_handle as *const lancedb::Table) };
+        let rt = get_simple_runtime();
+        match rt.block_on(async { table.alter_columns(&alterations).await }) {
+            Ok(res) => {
+                unsafe {
+                    *version_out = res.version;
+                }
+                SimpleResult::ok()
+            }
+            Err(e) => SimpleResult::error(format!("alter_columns failed: {}", e)),
+        }
+    });
+
+    match result {
+        Ok(res) => Box::into_raw(Box::new(res)),
+        Err(_) => Box::into_raw(Box::new(SimpleResult::error(
+            "Panic in simple_lancedb_table_alter_columns".to_string(),
+        ))),
+    }
+}
+
+/// Drop columns from the table. `columns_json` is a JSON array of
+/// strings naming the columns to remove. Empty arrays are rejected.
+///
+/// On success, the new commit version is written to *version_out.
+#[no_mangle]
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+pub extern "C" fn simple_lancedb_table_drop_columns(
+    table_handle: *mut c_void,
+    columns_json: *const c_char,
+    version_out: *mut u64,
+) -> *mut SimpleResult {
+    let result = std::panic::catch_unwind(|| -> SimpleResult {
+        if table_handle.is_null() || columns_json.is_null() || version_out.is_null() {
+            return SimpleResult::error("Invalid null arguments".to_string());
+        }
+        let json = match from_c_str(columns_json) {
+            Ok(s) => s,
+            Err(e) => return SimpleResult::error(format!("Invalid columns_json: {}", e)),
+        };
+        let names: Vec<String> = match serde_json::from_str(&json) {
+            Ok(v) => v,
+            Err(e) => return SimpleResult::error(format!("Failed to parse columns_json: {}", e)),
+        };
+        if names.is_empty() {
+            return SimpleResult::error(
+                "drop_columns: columns must be a non-empty array".to_string(),
+            );
+        }
+        for (i, n) in names.iter().enumerate() {
+            if n.trim().is_empty() {
+                return SimpleResult::error(format!("drop_columns: columns[{}] is empty", i));
+            }
+        }
+
+        // lancedb::Table::drop_columns wants &[&str]; build the borrow
+        // slice from the owned Vec<String>.
+        let refs: Vec<&str> = names.iter().map(String::as_str).collect();
+
+        let table = unsafe { &*(table_handle as *const lancedb::Table) };
+        let rt = get_simple_runtime();
+        match rt.block_on(async { table.drop_columns(&refs).await }) {
+            Ok(res) => {
+                unsafe {
+                    *version_out = res.version;
+                }
+                SimpleResult::ok()
+            }
+            Err(e) => SimpleResult::error(format!("drop_columns failed: {}", e)),
+        }
+    });
+
+    match result {
+        Ok(res) => Box::into_raw(Box::new(res)),
+        Err(_) => Box::into_raw(Box::new(SimpleResult::error(
+            "Panic in simple_lancedb_table_drop_columns".to_string(),
+        ))),
+    }
+}


### PR DESCRIPTION
## Summary

Adds the `add_columns` / `alter_columns` / `drop_columns` surface from `lancedb::Table` to the Go bindings as a new optional capability extension `contracts.ITableSchemaEvolve`, layered on top of `ITable` the same way `ITableTimeTravel` (#38) and `ITableUpdateExpr` (#37) are. Each call returns the post-commit version.

```go
if se, ok := table.(contracts.ITableSchemaEvolve); ok {
    // Derive new column from existing rows.
    _, _ = se.AddColumns(ctx, []contracts.NewColumnTransform{
        {Name: "score_x2", Expression: "score * 2"},
    })

    // Rename a column.
    newName := "score_v2"
    _, _ = se.AlterColumns(ctx, []contracts.ColumnAlteration{
        {Path: "score", Rename: &newName},
    })

    // Drop a column. On-disk bytes are reclaimed on the next OptimizeCompact.
    _, _ = se.DropColumns(ctx, []string{"legacy_col"})
}
```

## Scope (v1)

- **AddColumns**: `NewColumnTransform::SqlExpressions` only. The `BatchUDF` / `Stream` / `Reader` / `AllNulls` variants are not exposed because they require closures or full Arrow IPC plumbing across the FFI boundary. SqlExpressions covers the common "derive from existing columns" case.
- **AlterColumns**: rename + nullable changes only. The `data_type` cast variant is deferred — it requires Arrow DataType serialization and is slated for a follow-up.
- **DropColumns**: full surface.

## Implementation notes

- FFI envelope mirrors the existing pattern: `SimpleResult`, `std::panic::catch_unwind`, the shared simple runtime, snake_case JSON for structured inputs, and a scalar out-pointer for the new commit version.
- New module: `rust/src/schema_evolve.rs`. Three exports added to `cbindgen.toml` allowlist; `serde` added as a direct dep (was already in the lancedb closure transitively, now needed for `#[derive(Deserialize)]` on the input shapes).
- Go side: new capability iface `contracts.ITableSchemaEvolve`, new types `contracts.NewColumnTransform` and `contracts.ColumnAlteration`, and the cgo glue at `pkg/internal/table_schema_evolve.go`. Compile-time assertion `var _ contracts.ITableSchemaEvolve = (*Table)(nil)` keeps the iface and impl in sync.

## Test plan

`pkg/tests/schema_evolve_test.go` covers:

- [x] **Edge** — empty / whitespace / nil inputs; empty Name / Expression / Path; unknown column; duplicate column; no-op alteration (neither rename nor nullable set); malformed SQL expression.
- [x] **Property** — single-expression `score * 2` evaluates correctly per row; multi-column add in one call; rename preserves data and row count; drop preserves row count and other columns.
- [x] **Round-trip** — `Add -> Alter (rename) -> Drop` returns the schema to its original field set, with strictly increasing version numbers across each step.
- [x] **Closed-table guards** for all three methods.
- [x] **Nullable widening** (`false -> true`) as the supported direction; nullable tightening (`true -> false`) explicitly covered as a "backend rejects" path since lance refuses to tighten nullability even on null-free data.

```
$ go test ./pkg/tests/ -run TestSchemaEvolve -v
=== RUN   TestSchemaEvolve
    --- PASS: TestSchemaEvolve/AddColumnsSqlExpressionProperty (0.21s)
    --- PASS: TestSchemaEvolve/AddColumnsMultipleAtOnce (0.01s)
    --- PASS: TestSchemaEvolve/AddColumnsRejectsBadInput (0.01s)
    --- PASS: TestSchemaEvolve/AlterColumnsRename (0.00s)
    --- PASS: TestSchemaEvolve/AlterColumnsNullableToggle (0.00s)
    --- PASS: TestSchemaEvolve/AlterColumnsNullableTighteningRejected (0.00s)
    --- PASS: TestSchemaEvolve/AlterColumnsRejectsBadInput (0.00s)
    --- PASS: TestSchemaEvolve/DropColumnsBasic (0.00s)
    --- PASS: TestSchemaEvolve/DropColumnsMultiple (0.00s)
    --- PASS: TestSchemaEvolve/DropColumnsRejectsBadInput (0.00s)
    --- PASS: TestSchemaEvolve/AddAlterDropRoundTrip (0.01s)
    --- PASS: TestSchemaEvolve/ClosedTableReturnsError (0.00s)
PASS
```

Full `go test ./...` and `cargo clippy --release -- -D warnings` and `golangci-lint run ./...` all clean on `linux/amd64`.