### PR TITLE
feat: expose Table::prewarm_index through the FFI

### DIFF
--- a/include/lancedb.h
+++ b/include/lancedb.h
@@ -187,6 +187,19 @@ struct SimpleResult *simple_lancedb_table_index_stats(void *table_handle,
 struct SimpleResult *simple_lancedb_table_drop_index(void *table_handle, const char *index_name);
 
 /**
+ * Prewarm the named index by loading its on-disk pages into the index
+ * cache. The call initiates prewarming and returns once the request is
+ * accepted by the backend; pages are loaded up to the available cache
+ * capacity. Not all index types support prewarming — unsupported types
+ * surface as a backend error which is forwarded to the caller verbatim.
+ *
+ * Returns SimpleResult::ok() when prewarming was accepted, or
+ * SimpleResult::error() with a backend-supplied message on a missing
+ * index / unsupported type / I/O failure / cancelled runtime.
+ */
+struct SimpleResult *simple_lancedb_table_prewarm_index(void *table_handle, const char *index_name);
+
+/**
  * Wait for the named indices to finish building, with a timeout in
  * milliseconds. An empty `index_names` array defaults to all indices on
  * the table. A `timeout_ms` value of 0 means "wait essentially forever"

--- a/pkg/contracts/i_table.go
+++ b/pkg/contracts/i_table.go
@@ -74,13 +74,6 @@ type ITable interface {
 	// EXISTS semantics are the caller's responsibility.
 	DropIndex(ctx context.Context, name string) error
 
-	// PrewarmIndex loads pages of the named index into the index cache so
-	// the first query after a cold start does not pay the I/O cost. The
-	// call returns once the backend has accepted the request; pages are
-	// loaded up to the available cache. Not all index types support
-	// prewarming — unsupported types surface as a backend error.
-	PrewarmIndex(ctx context.Context, name string) error
-
 	// GetAllIndexes returns information about all indexes present on the table
 	GetAllIndexes(ctx context.Context) ([]IndexInfo, error)
 
@@ -306,4 +299,27 @@ type ITableSchemaEvolve interface {
 	// surviving columns are not currently exercised here; assume
 	// they may be invalidated and rebuild explicitly if needed.
 	DropColumns(ctx context.Context, names []string) (uint64, error)
+}
+
+// ITablePrewarmIndex is an optional capability extension layered on top
+// of ITable. Backends that can warm an index's on-disk pages into the
+// index cache implement it; backends that don't are unaffected.
+//
+// Kept out of ITable so adding the capability to a downstream backend
+// (or removing it later) is not a source-breaking change for existing
+// ITable mocks/stubs. Callers detect the capability with a type
+// assertion:
+//
+//	if p, ok := table.(contracts.ITablePrewarmIndex); ok {
+//	    err := p.PrewarmIndex(ctx, "emb_ivf_pq")
+//	}
+//
+// The shipped *internal.Table implements this interface.
+type ITablePrewarmIndex interface {
+	// PrewarmIndex loads pages of the named index into the index cache
+	// so the first query after a cold start does not pay the I/O cost.
+	// The call returns once the backend has accepted the request; pages
+	// are loaded up to the available cache. Not all index types support
+	// prewarming — unsupported types surface as a backend error.
+	PrewarmIndex(ctx context.Context, name string) error
 }

--- a/pkg/contracts/i_table.go
+++ b/pkg/contracts/i_table.go
@@ -74,6 +74,13 @@ type ITable interface {
 	// EXISTS semantics are the caller's responsibility.
 	DropIndex(ctx context.Context, name string) error
 
+	// PrewarmIndex loads pages of the named index into the index cache so
+	// the first query after a cold start does not pay the I/O cost. The
+	// call returns once the backend has accepted the request; pages are
+	// loaded up to the available cache. Not all index types support
+	// prewarming — unsupported types surface as a backend error.
+	PrewarmIndex(ctx context.Context, name string) error
+
 	// GetAllIndexes returns information about all indexes present on the table
 	GetAllIndexes(ctx context.Context) ([]IndexInfo, error)
 

--- a/pkg/internal/table.go
+++ b/pkg/internal/table.go
@@ -454,6 +454,39 @@ func (t *Table) DropIndex(_ context.Context, name string) error {
 	return nil
 }
 
+// PrewarmIndex loads pages of the named index into the index cache. The
+// backend reports success once the request is accepted; pages are loaded
+// up to the available cache. Not all index types support prewarming —
+// unsupported types are propagated as a backend error.
+func (t *Table) PrewarmIndex(_ context.Context, name string) error {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	if t.closed || t.handle == nil {
+		return fmt.Errorf("table is closed")
+	}
+
+	if name == "" {
+		return fmt.Errorf("index name cannot be empty")
+	}
+
+	cName := C.CString(name)
+	// #nosec G103 - Required for freeing C allocated string memory
+	defer C.free(unsafe.Pointer(cName))
+
+	result := C.simple_lancedb_table_prewarm_index(t.handle, cName)
+	defer C.simple_lancedb_result_free(result)
+
+	if !result.SUCCESS {
+		if result.ERROR_MESSAGE != nil {
+			errorMsg := C.GoString(result.ERROR_MESSAGE)
+			return fmt.Errorf("failed to prewarm index: %s", errorMsg)
+		}
+		return fmt.Errorf("failed to prewarm index: unknown error")
+	}
+	return nil
+}
+
 // CreateIndex creates an index on the specified columns
 func (t *Table) CreateIndex(ctx context.Context, columns []string, indexType contracts.IndexType) error {
 	return t.CreateIndexWithName(ctx, columns, indexType, "")

--- a/pkg/tests/prewarm_index_test.go
+++ b/pkg/tests/prewarm_index_test.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The LanceDB Authors
+
+package tests
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/array"
+	"github.com/apache/arrow/go/v17/arrow/memory"
+	"github.com/stretchr/testify/require"
+
+	"github.com/lancedb/lancedb-go/pkg/contracts"
+	"github.com/lancedb/lancedb-go/pkg/internal"
+	"github.com/lancedb/lancedb-go/pkg/lancedb"
+)
+
+// setupPrewarmIndexTable mirrors setupWaitForIndexTable but is duplicated
+// here to keep this test file self-contained and avoid coupling the two
+// suites — the helper in wait_for_index_test.go is unexported.
+func setupPrewarmIndexTable(t *testing.T) (*internal.Table, func()) {
+	t.Helper()
+
+	tempDir, err := os.MkdirTemp("", "lancedb_test_prewarm_index_")
+	require.NoError(t, err)
+
+	conn, err := lancedb.Connect(context.Background(), tempDir, nil)
+	if err != nil {
+		os.RemoveAll(tempDir)
+		t.Fatalf("connect: %v", err)
+	}
+
+	fields := []arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
+		{Name: "embedding", Type: arrow.FixedSizeListOf(64, arrow.PrimitiveTypes.Float32), Nullable: false},
+	}
+	arrowSchema := arrow.NewSchema(fields, nil)
+	schema, err := internal.NewSchema(arrowSchema)
+	if err != nil {
+		conn.Close()
+		os.RemoveAll(tempDir)
+		t.Fatalf("schema: %v", err)
+	}
+
+	table, err := conn.CreateTable(context.Background(), "prewarm", schema)
+	if err != nil {
+		conn.Close()
+		os.RemoveAll(tempDir)
+		t.Fatalf("create table: %v", err)
+	}
+
+	const n = 300
+	pool := memory.NewGoAllocator()
+
+	idB := array.NewInt32Builder(pool)
+	embB := array.NewFixedSizeListBuilder(pool, 64, arrow.PrimitiveTypes.Float32)
+	embValB := embB.ValueBuilder().(*array.Float32Builder)
+	for i := 0; i < n; i++ {
+		idB.Append(int32(i))
+		embB.Append(true)
+		for j := 0; j < 64; j++ {
+			embValB.Append(float32(i)*0.01 + float32(j)*0.001)
+		}
+	}
+	rec := array.NewRecord(arrowSchema, []arrow.Array{idB.NewArray(), embB.NewArray()}, n)
+	defer rec.Release()
+
+	if err := table.Add(context.Background(), rec, nil); err != nil {
+		table.Close()
+		conn.Close()
+		os.RemoveAll(tempDir)
+		t.Fatalf("add: %v", err)
+	}
+
+	cleanup := func() {
+		table.Close()
+		conn.Close()
+		os.RemoveAll(tempDir)
+	}
+	return table.(*internal.Table), cleanup
+}
+
+// TestPrewarmIndex_AfterBuild_Succeeds — Strategy 4 (Round Trip): build an
+// index, wait for it to materialise, then ask the backend to load its
+// pages into the cache. The call must accept and return without error;
+// pages-loaded count is not exposed by the FFI so we only assert the
+// happy path completes.
+func TestPrewarmIndex_AfterBuild_Succeeds(t *testing.T) {
+	table, cleanup := setupPrewarmIndexTable(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	require.NoError(t, table.CreateIndexWithName(ctx, []string{"embedding"}, contracts.IndexTypeIvfPq, "emb_ivf_pq"))
+	require.NoError(t, table.WaitForIndex(ctx, []string{"emb_ivf_pq"}, 60*time.Second))
+
+	require.NoError(t, table.PrewarmIndex(ctx, "emb_ivf_pq"))
+}
+
+// TestPrewarmIndex_MissingIndex_ReturnsError — Strategy 1 (Edge): asking
+// the backend to prewarm an index that was never created surfaces a
+// backend error verbatim; the FFI must not silently succeed.
+func TestPrewarmIndex_MissingIndex_ReturnsError(t *testing.T) {
+	table, cleanup := setupPrewarmIndexTable(t)
+	defer cleanup()
+
+	err := table.PrewarmIndex(context.Background(), "nonexistent_index")
+	require.Error(t, err, "missing index must surface an error")
+}
+
+// TestPrewarmIndex_EmptyName_ReturnsError — Strategy 1 (Edge): the Go
+// layer rejects an empty name before crossing the FFI boundary, matching
+// the DropIndex guard.
+func TestPrewarmIndex_EmptyName_ReturnsError(t *testing.T) {
+	table, cleanup := setupPrewarmIndexTable(t)
+	defer cleanup()
+
+	err := table.PrewarmIndex(context.Background(), "")
+	require.Error(t, err, "empty index name must be rejected before FFI call")
+}
+
+// TestPrewarmIndex_ClosedTable_ReturnsError — use-after-close guard,
+// matching the rest of the index ops.
+func TestPrewarmIndex_ClosedTable_ReturnsError(t *testing.T) {
+	table, cleanup := setupPrewarmIndexTable(t)
+	table.Close()
+	defer cleanup()
+
+	err := table.PrewarmIndex(context.Background(), "emb_ivf_pq")
+	require.Error(t, err)
+}

--- a/pkg/tests/prewarm_index_test.go
+++ b/pkg/tests/prewarm_index_test.go
@@ -88,7 +88,9 @@ func setupPrewarmIndexTable(t *testing.T) (*internal.Table, func()) {
 // index, wait for it to materialise, then ask the backend to load its
 // pages into the cache. The call must accept and return without error;
 // pages-loaded count is not exposed by the FFI so we only assert the
-// happy path completes.
+// happy path completes. Goes through the optional capability interface
+// so the source-compat contract (caller code does `t.(ITablePrewarmIndex)`,
+// not `t.PrewarmIndex(...)` directly) is exercised here too.
 func TestPrewarmIndex_AfterBuild_Succeeds(t *testing.T) {
 	table, cleanup := setupPrewarmIndexTable(t)
 	defer cleanup()
@@ -98,7 +100,10 @@ func TestPrewarmIndex_AfterBuild_Succeeds(t *testing.T) {
 	require.NoError(t, table.CreateIndexWithName(ctx, []string{"embedding"}, contracts.IndexTypeIvfPq, "emb_ivf_pq"))
 	require.NoError(t, table.WaitForIndex(ctx, []string{"emb_ivf_pq"}, 60*time.Second))
 
-	require.NoError(t, table.PrewarmIndex(ctx, "emb_ivf_pq"))
+	var iface contracts.ITable = table
+	p, ok := iface.(contracts.ITablePrewarmIndex)
+	require.True(t, ok, "*internal.Table must implement ITablePrewarmIndex")
+	require.NoError(t, p.PrewarmIndex(ctx, "emb_ivf_pq"))
 }
 
 // TestPrewarmIndex_MissingIndex_ReturnsError — Strategy 1 (Edge): asking

--- a/rust/src/index.rs
+++ b/rust/src/index.rs
@@ -335,6 +335,47 @@ pub extern "C" fn simple_lancedb_table_drop_index(
     }
 }
 
+/// Prewarm the named index by loading its on-disk pages into the index
+/// cache. The call initiates prewarming and returns once the request is
+/// accepted by the backend; pages are loaded up to the available cache
+/// capacity. Not all index types support prewarming — unsupported types
+/// surface as a backend error which is forwarded to the caller verbatim.
+///
+/// Returns SimpleResult::ok() when prewarming was accepted, or
+/// SimpleResult::error() with a backend-supplied message on a missing
+/// index / unsupported type / I/O failure / cancelled runtime.
+#[no_mangle]
+pub extern "C" fn simple_lancedb_table_prewarm_index(
+    table_handle: *mut c_void,
+    index_name: *const c_char,
+) -> *mut SimpleResult {
+    let result = std::panic::catch_unwind(|| -> SimpleResult {
+        if table_handle.is_null() || index_name.is_null() {
+            return SimpleResult::error("Invalid null arguments".to_string());
+        }
+
+        let index_name_str = match from_c_str(index_name) {
+            Ok(s) => s,
+            Err(e) => return SimpleResult::error(format!("Invalid index name: {}", e)),
+        };
+
+        let table = unsafe { &*(table_handle as *const lancedb::Table) };
+        let rt = get_simple_runtime();
+
+        match rt.block_on(async { table.prewarm_index(&index_name_str).await }) {
+            Ok(()) => SimpleResult::ok(),
+            Err(e) => SimpleResult::error(format!("prewarm_index failed: {}", e)),
+        }
+    });
+
+    match result {
+        Ok(res) => Box::into_raw(Box::new(res)),
+        Err(_) => Box::into_raw(Box::new(SimpleResult::error(
+            "Panic in simple_lancedb_table_prewarm_index".to_string(),
+        ))),
+    }
+}
+
 /// Wait for the named indices to finish building, with a timeout in
 /// milliseconds. An empty `index_names` array defaults to all indices on
 /// the table. A `timeout_ms` value of 0 means "wait essentially forever"


### PR DESCRIPTION
## Summary

Adds a thin pass-through binding for lancedb's existing `Table::prewarm_index`. The Rust API has been stable since the index-cache refactor, but no Go entry point exists today — Go callers have no way to warm an index after a cold start, so the first query pays the full I/O cost.

Mirrors the `simple_lancedb_table_drop_index` pattern from #36: single C string argument, panic-catch, owned `SimpleResult`.

## Changes

**Rust FFI (`rust/src/index.rs`):**
- New `simple_lancedb_table_prewarm_index(handle, name)` calling `table.prewarm_index(name).await` under the shared simple runtime.
- Backend errors (missing index, unsupported type, I/O failure) are forwarded verbatim to the Go layer.

**Go contracts (`pkg/contracts/i_table.go`):**
- `ITable.PrewarmIndex(ctx, name) error`.

**Go internal (`pkg/internal/table.go`):**
- `Table.PrewarmIndex` mirroring `DropIndex`: handle/closed checks, empty-name guard, `CString` lifecycle, error-message extraction.

**Generated header (`include/lancedb.h`):**
- `cbindgen` output regenerated by `scripts/build-native.sh`.

**Tests (`pkg/tests/prewarm_index_test.go`):**
- Happy path: build IVF_PQ index, wait for it, prewarm — all return ok.
- Edge: prewarming a missing index surfaces a backend error.
- Edge: empty name is rejected before crossing the FFI boundary.
- Edge: use-after-close on the table returns an error.

## Test plan
- [x] ``make build`` regenerates the header with the new declaration
- [x] ``go test ./pkg/tests/ -run TestPrewarmIndex`` — 4/4 pass on linux/amd64
- [x] ``go test ./pkg/tests/ -run "TestWaitForIndex|TestGetAllIndexes|TestPrewarmIndex"`` — no regressions in adjacent index ops