### PR TITLE
feat: use cargo-zigbuild for cross-compiles, add Windows ARM64, drop unused cdylib

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,12 @@ jobs:
           go-version: '1.24'
           cache: true
 
+      # Required by scripts/build-native.sh to bootstrap cargo-zigbuild via pip.
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
       # Install system dependencies
       - name: Install system dependencies (Linux)
         if: matrix.os == 'ubuntu-latest'

--- a/Makefile
+++ b/Makefile
@@ -40,16 +40,13 @@ else ifeq ($(UNAME_S),Linux)
 	CGO_LDFLAGS := $(CURRENT_DIR)/lib/linux_$(ARCH)/liblancedb_go.a $(SYSTEM_LIBS)
 else ifneq (,$(findstring MINGW,$(UNAME_S)))
 	PLATFORM := windows
-	ARCH := amd64
-	CGO_LDFLAGS := $(CURRENT_DIR)/lib/windows_amd64/liblancedb_go.a
+	CGO_LDFLAGS := $(CURRENT_DIR)/lib/windows_$(ARCH)/liblancedb_go.a
 else ifneq (,$(findstring MSYS,$(UNAME_S)))
 	PLATFORM := windows
-	ARCH := amd64
-	CGO_LDFLAGS := $(CURRENT_DIR)/lib/windows_amd64/liblancedb_go.a
+	CGO_LDFLAGS := $(CURRENT_DIR)/lib/windows_$(ARCH)/liblancedb_go.a
 else ifneq (,$(findstring CYGWIN,$(UNAME_S)))
 	PLATFORM := windows
-	ARCH := amd64
-	CGO_LDFLAGS := $(CURRENT_DIR)/lib/windows_amd64/liblancedb_go.a
+	CGO_LDFLAGS := $(CURRENT_DIR)/lib/windows_$(ARCH)/liblancedb_go.a
 else
 	$(error Unsupported platform: $(UNAME_S))
 endif

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -13,7 +13,7 @@ publish = false
 
 [lib]
 name = "lancedb_go"
-crate-type = ["cdylib", "staticlib"]
+crate-type = ["staticlib"]
 path = "src/lib_simple.rs"
 
 [dependencies]

--- a/scripts/build-all-platforms.sh
+++ b/scripts/build-all-platforms.sh
@@ -20,7 +20,8 @@ PLATFORMS=(
     "darwin arm64" 
     "linux amd64"
     "linux arm64"
-    # "windows amd64"  # Uncomment if building on Windows or with cross-compilation setup
+    "windows amd64"  # Uncomment if building on Windows or with cross-compilation setup
+    "windows arm64"
 )
 
 # Check prerequisites

--- a/scripts/build-native.sh
+++ b/scripts/build-native.sh
@@ -15,6 +15,19 @@ RUST_DIR="$PROJECT_ROOT/rust"
 LIB_DIR="$PROJECT_ROOT/lib"
 INCLUDE_DIR="$PROJECT_ROOT/include"
 
+# Auto-install cargo-zigbuild if missing. `pip install cargo-zigbuild` pulls
+# `ziglang` (the zig binary) as a dependency, so one pip call bootstraps both.
+# Requires bash + Python 3 — Windows users run via Git Bash or WSL.
+if ! command -v cargo-zigbuild >/dev/null 2>&1; then
+    if command -v python3 >/dev/null 2>&1; then PY=python3
+    elif command -v python  >/dev/null 2>&1; then PY=python
+    else echo "❌ Python 3 required: https://www.python.org/downloads/" >&2; exit 1
+    fi
+    echo "📦 Installing cargo-zigbuild via pip..."
+    "$PY" -m pip install --break-system-packages cargo-zigbuild
+    export PATH="$("$PY" -c 'import sysconfig; print(sysconfig.get_path("scripts"))'):$PATH"
+fi
+
 # Default to current platform if not specified
 PLATFORM="${1:-$(uname -s | tr '[:upper:]' '[:lower:]')}"
 ARCH="${2:-$(uname -m)}"
@@ -55,6 +68,7 @@ case "$PLATFORM-$ARCH" in
     "linux-amd64") RUST_TARGET="x86_64-unknown-linux-gnu" ;;
     "linux-arm64") RUST_TARGET="aarch64-unknown-linux-gnu" ;;
     "windows-amd64") RUST_TARGET="x86_64-pc-windows-gnu" ;;
+    "windows-arm64") RUST_TARGET="aarch64-pc-windows-gnullvm" ;;
     "windows-gnu-amd64") RUST_TARGET="x86_64-pc-windows-gnu" ;;
     "windows-msvc-amd64") RUST_TARGET="x86_64-pc-windows-msvc" ;;
     *) echo "Unsupported target: $PLATFORM-$ARCH" >&2; exit 1 ;;
@@ -74,7 +88,7 @@ if [[ "$PLATFORM" == "darwin" ]]; then
 fi
 
 # Build the library
-CARGO_TARGET_DIR="$RUST_DIR/target" cargo build --release --target "$RUST_TARGET" \
+CARGO_TARGET_DIR="$RUST_DIR/target" cargo zigbuild --release --target "$RUST_TARGET" \
     --features aws,gcs,azure
 
 # Copy library to distribution directory


### PR DESCRIPTION
## Summary

Switches cross-compiles to `cargo-zigbuild` so any host can build all targets without per-platform toolchains (no MSVC, no MinGW, no Linux sysroots). With that in place, adding Windows ARM64 to the build matrix is a small change.

Also drops the `cdylib` crate output. The Go bindings statically link `liblancedb_go.a` ([Makefile:36,40,44](Makefile#L36)), so the `.dylib` / `.so` / `lancedb_go.dll` outputs were never used — about 200MB of dead artifact per arch.

Windows ARM64 wasn't wired end-to-end: no rust target mapping, missing from the platforms list, and the Makefile hardcoded `ARCH := amd64` in every Windows branch. This PR closes the gap so it works the same way darwin/linux already do.

## Changes

**[scripts/build-native.sh](scripts/build-native.sh):**
- Use `cargo zigbuild` instead of `cargo build`.
- Add `windows-arm64 → aarch64-pc-windows-gnullvm` target mapping.
- Auto-install `cargo-zigbuild` via `pip install --break-system-packages cargo-zigbuild` if missing.

**[scripts/build-all-platforms.sh](scripts/build-all-platforms.sh):**
- Add `"windows arm64"` to `PLATFORMS`.

**[Makefile](Makefile#L41-L52):**
- Windows branches use `lib/windows_$(ARCH)/` and inherit the top-level arch detection.

**[rust/Cargo.toml](rust/Cargo.toml):**
- `crate-type = ["staticlib"]` (was `["cdylib", "staticlib"]`).

**[.github/workflows/ci.yml](.github/workflows/ci.yml):**
- Add `actions/setup-python@v5` step to the `build-artifacts` job so `build-native.sh` can install `cargo-zigbuild` on the runner.

## Test plan

- [x] `./scripts/build-native.sh windows arm64` builds clean from a non-Windows host
- [x] `make build-all-platforms` builds clean, was tested on `MacOS 26.4.1`
- [x] `go test ./pkg/tests/` passes on darwin/arm64 and linux/amd64